### PR TITLE
Fix release order of ReleaseT

### DIFF
--- a/src/main/frege/frege/control/monad/trans/Resource.fr
+++ b/src/main/frege/frege/control/monad/trans/Resource.fr
@@ -10,7 +10,7 @@ import frege.control.monad.trans.MaybeT (MaybeT)
 import frege.control.monad.trans.MonadIO (MonadIO, liftIO)
 import frege.control.monad.trans.MonadTrans (MonadTrans, lift)
 import frege.control.monad.State (StateT)
-import frege.data.HashMap (HashMap)
+import frege.data.TreeMap (TreeMap)
 
 --- A @Monad@ which allows for safe resource allocation. In theory, any monad
 --- transformer stack which includes a @ResourceT@ can be an instance of
@@ -118,7 +118,7 @@ private register' istate rel = do
     rm <- istate.get
     (rm', key) <- case rm of
         ReleaseMap key rf m ->
-            pure ( ReleaseMap (key - 1) rf (HashMap.insert key (const rel) m)
+            pure ( ReleaseMap (key - 1) rf (TreeMap.insert key (const rel) m)
                  , ReleaseKey istate key
                  )
         ReleaseMapClosed -> fail "register'"
@@ -139,10 +139,10 @@ private release' istate key act = do
     act maction
   where
     lookupAction (rm@(ReleaseMap next rf m)) =
-        case HashMap.lookup key m of
+        case TreeMap.lookup key m of
             Nothing -> (rm, Nothing)
             Just action ->
-                ( ReleaseMap next rf $ HashMap.delete key m
+                ( ReleaseMap next rf $ TreeMap.delete key m
                 , Just (action ReleaseEarly)
                 )
     -- We tried to call release, but since the state is already closed, we
@@ -157,7 +157,7 @@ transResourceT :: (m a -> n b) -> ResourceT m a -> ResourceT n b
 transResourceT f (ResourceT.Mk mx) = ResourceT.Mk (\r -> f (mx r))
 
 
-type IntMap = HashMap Int
+type IntMap = TreeMap Int
 
 --- A lookup key for a specific release action. This value is returned by
 --- 'register' and 'allocate', and is passed to 'release'.
@@ -208,7 +208,7 @@ stateCleanupChecked morig istate = do
         pure mm
     case mm of
         Just m -> do
-            res <- mapMaybeReverseM (\x -> try (x rtype)) $ HashMap.values m
+            res <- mapMaybeReverseM (\x -> try (x rtype)) $ elems m
             case res of
                 [] -> return () -- nothing went wrong
                 -- e:es -> E.throwIO $ ResourceCleanupException morig e es
@@ -219,6 +219,11 @@ stateCleanupChecked morig istate = do
     try io = fmap (either Just (\() -> Nothing)) (catchAll io)
 
     rtype = maybe ReleaseNormal (const ReleaseException) morig
+
+    -- I believe TreeMap.values is sorted by their keys but Froogle says
+    -- otherwise. TreeMap.each, on the other hand, is stated to be sorted.
+    elems :: TreeMap a b -> [b]
+    elems = map snd . TreeMap.each
 
 -- Note that this returns values in reverse order, which is what we
 -- want in the specific case of this function.

--- a/src/test/frege/frege/control/monad/trans/ResourceTest.fr
+++ b/src/test/frege/frege/control/monad/trans/ResourceTest.fr
@@ -1,0 +1,29 @@
+module frege.control.monad.trans.ResourceTest where
+
+import frege.control.monad.trans.Resource (MonadResource, allocate, runResourceT)
+import test.HspecLike (shouldBe)
+
+data Action = Acquire Int | Release Int
+derive Eq Action
+derive Show Action
+
+allocateAction :: MonadResource m => IORef [Action] -> Int -> m ()
+allocateAction actions i =
+  void $ allocate
+    (      actions.modify (Acquire i :))
+    (\_ -> actions.modify (Release i :))
+
+--- Makes sure that resources are released in the reverse order.
+orderedRelease :: IO ()
+orderedRelease = do
+    actions <- Ref.new []
+    runResourceT $ do
+        allocateAction actions 0
+        allocateAction actions 1
+    xs <- actions.get
+    -- xs should contain the reversed order of the performed actions
+    xs `shouldBe` [Release 0, Release 1, Acquire 1, Acquire 0]
+
+main :: IO ()
+main = do
+    orderedRelease

--- a/src/test/frege/frege/data/conduit/CombinatorsTest.fr
+++ b/src/test/frege/frege/data/conduit/CombinatorsTest.fr
@@ -1,20 +1,10 @@
 module frege.data.conduit.CombinatorsTest where
 
 import frege.data.Conduit (.|, runConduitRes)
-
-import frege.data.conduit.Combinators as C ()
 import frege.data.Traversable (traverse)
+import frege.data.conduit.Combinators as C ()
 import frege.java.IO (File)
-
-shouldBe :: (Show a, Eq a) => a -> a -> IO ()
-shouldBe a b
-  | a == b = pure ()
-  | otherwise = fail $ "expected: " ++ show a ++ ", but got: " ++ show b
-
-shouldSatisfy :: Show a => a -> (a -> Bool) -> IO ()
-shouldSatisfy a f
-  | f a = pure ()
-  | otherwise = fail $ show a ++ " didn't satisfy the expectation"
+import test.HspecLike (shouldBe, shouldSatisfy)
 
 bracket :: IO a -> (a -> IO b) -> (a -> IO c) -> IO c
 bracket open close work = do

--- a/src/test/frege/test/HspecLike.fr
+++ b/src/test/frege/test/HspecLike.fr
@@ -1,0 +1,13 @@
+module test.HspecLike where
+
+type Expectation = IO ()
+
+shouldBe :: (Show a, Eq a) => a -> a -> Expectation
+shouldBe a b
+  | a == b = pure ()
+  | otherwise = fail $ "expected: " ++ show b ++ ", but got: " ++ show a
+
+shouldSatisfy :: Show a => a -> (a -> Bool) -> Expectation
+shouldSatisfy a f
+  | f a = pure ()
+  | otherwise = fail $ show a ++ " didn't satisfy the expectation"


### PR DESCRIPTION
`runResourceT` should release resources in the reverse order in which resources are acquired.

The implementation depends on the ordering of values in `IntMap`. In Haskell, `IntMap.elems` produces values with their keys sorted in the ascending order. To reproduce that behavior in Frege, `IntMap` should be an alias of `TreeMap Int`, not `HashMap Int`.