### PR TITLE
Fix fregedoc

### DIFF
--- a/src/main/frege/frege/control/monad/io/Unlift.fr
+++ b/src/main/frege/frege/control/monad/io/Unlift.fr
@@ -31,14 +31,14 @@ newtype UnliftIO m = UnliftIO { run :: forall a. m a -> IO a }
    Laws. For any value @u@ returned by 'askUnliftIO', it must meet the
    monad transformer laws as reformulated for @MonadUnliftIO@:
 
-   * @unliftIO u . return = return@
+   - @unliftIO u . return = return@
 
-   * @unliftIO u (m >>= f) = unliftIO u m >>= unliftIO u . f@
+   - @unliftIO u (m >>= f) = unliftIO u m >>= unliftIO u . f@
 
    The third is a currently nameless law which ensures that the
    current context is preserved.
 
-   * @askUnliftIO >>= (\u -> liftIO (unliftIO u m)) = m@
+   - @askUnliftIO >>= (\u -> liftIO (unliftIO u m)) = m@
 
    If you have a name for this, please submit it in a pull request for
    great glory.

--- a/src/main/frege/frege/control/monad/io/Unlift.fr
+++ b/src/main/frege/frege/control/monad/io/Unlift.fr
@@ -1,42 +1,48 @@
---- Ported from Haskell unliftio-core library
---- Copyright   :  (C) 2017 FP Complete
---- License     :  MIT
+{--
+   Ported from Haskell unliftio-core library
+   Copyright   :  (C) 2017 FP Complete
+   License     :  MIT
+ -}
 -- TODO split into subproject
 module frege.control.monad.io.Unlift where
 
 import frege.control.monad.trans.MonadIO (MonadIO)
 
---- The ability to run any monadic action @m a@ as @IO a@.
----
---- This is more precisely a natural transformation. We need to new
---- datatype (instead of simply using a @forall@) due to lack of
---- support in Frege for impredicative types.
+{--
+   The ability to run any monadic action @m a@ as @IO a@.
+
+   This is more precisely a natural transformation. We need to new
+   datatype (instead of simply using a @forall@) due to lack of
+   support in Frege for impredicative types.
+ -}
 newtype UnliftIO m = UnliftIO { run :: forall a. m a -> IO a }
 
---- Monads which allow their actions to be run in 'IO'.
----
---- While 'MonadIO' allows an 'IO' action to be lifted into another
---- monad, this class captures the opposite concept: allowing you to
---- capture the monadic context. Note that, in order to meet the laws
---- given below, the intuition is that a monad must have no monadic
---- state, but may have monadic context. This essentially limits
---- 'MonadUnliftIO' to 'ReaderT' and 'IdentityT' transformers on top of
---- 'IO'.
----
---- Laws. For any value @u@ returned by 'askUnliftIO', it must meet the
---- monad transformer laws as reformulated for @MonadUnliftIO@:
----
---- * @unliftIO u . return = return@
----
---- * @unliftIO u (m >>= f) = unliftIO u m >>= unliftIO u . f@
----
---- The third is a currently nameless law which ensures that the
---- current context is preserved.
----
---- * @askUnliftIO >>= (\u -> liftIO (unliftIO u m)) = m@
----
---- If you have a name for this, please submit it in a pull request for
---- great glory.
+{--
+   Monads which allow their actions to be run in 'IO'.
+
+   While 'MonadIO' allows an 'IO' action to be lifted into another
+   monad, this class captures the opposite concept: allowing you to
+   capture the monadic context. Note that, in order to meet the laws
+   given below, the intuition is that a monad must have no monadic
+   state, but may have monadic context. This essentially limits
+   'MonadUnliftIO' to 'ReaderT' and 'IdentityT' transformers on top of
+   'IO'.
+
+   Laws. For any value @u@ returned by 'askUnliftIO', it must meet the
+   monad transformer laws as reformulated for @MonadUnliftIO@:
+
+   * @unliftIO u . return = return@
+
+   * @unliftIO u (m >>= f) = unliftIO u m >>= unliftIO u . f@
+
+   The third is a currently nameless law which ensures that the
+   current context is preserved.
+
+   * @askUnliftIO >>= (\u -> liftIO (unliftIO u m)) = m@
+
+   If you have a name for this, please submit it in a pull request for
+   great glory.
+ -}
 class MonadIO m => MonadUnliftIO m where
   --- Capture the current monadic context, providing the ability to
   --- run monadic actions in 'IO'.
@@ -56,9 +62,9 @@ instance MonadUnliftIO IO where
   withRunInIO inner = inner id
 
 {--
- - Convenience function for capturing the monadic context and running an 'IO'
- - action. The 'UnliftIO' newtype wrapper is rarely needed, so prefer
- - 'withRunInIO' to this function.
+   Convenience function for capturing the monadic context and running an 'IO'
+   action. The 'UnliftIO' newtype wrapper is rarely needed, so prefer
+   'withRunInIO' to this function.
  -}
 withUnliftIO :: MonadUnliftIO m => (UnliftIO m -> IO a) -> m a
 withUnliftIO inner = do

--- a/src/main/frege/frege/control/monad/trans/Resource.fr
+++ b/src/main/frege/frege/control/monad/trans/Resource.fr
@@ -1,6 +1,8 @@
---- Ported from Haskell resourcet library
---- Copyright   :  (C) Michael Snoyman
---- License     :  BSD3
+{--
+   Ported from Haskell resourcet library
+   Copyright   :  (C) Michael Snoyman
+   License     :  BSD3
+ -}
 -- TODO split into subproject
 -- TODO atomicity, thrown exception, and masking
 module frege.control.monad.trans.Resource where
@@ -12,15 +14,17 @@ import frege.control.monad.trans.MonadTrans (MonadTrans, lift)
 import frege.control.monad.State (StateT)
 import frege.data.TreeMap (TreeMap)
 
---- A @Monad@ which allows for safe resource allocation. In theory, any monad
---- transformer stack which includes a @ResourceT@ can be an instance of
---- @MonadResource@.
----
---- Note: @runResourceT@ has a requirement for a @MonadUnliftIO m@ monad,
---- which allows control operations to be lifted. A @MonadResource@ does not
---- have this requirement. This means that transformers such as @ContT@ can be
---- an instance of @MonadResource@. However, the @ContT@ wrapper will need to be
---- unwrapped before calling @runResourceT@.
+{--
+   A @Monad@ which allows for safe resource allocation. In theory, any monad
+   transformer stack which includes a @ResourceT@ can be an instance of
+   @MonadResource@.
+
+   Note: @runResourceT@ has a requirement for a @MonadUnliftIO m@ monad,
+   which allows control operations to be lifted. A @MonadResource@ does not
+   have this requirement. This means that transformers such as @ContT@ can be
+   an instance of @MonadResource@. However, the @ContT@ wrapper will need to be
+   unwrapped before calling @runResourceT@.
+ -}
 class MonadIO m => MonadResource m where
     --- Lift a @ResourceT IO@ action into the current @Monad@.
     liftResourceT :: ResourceT IO a -> m a
@@ -82,15 +86,17 @@ instance MonadResource m => MonadResource (MaybeT m) where
 instance MonadResource m => MonadResource (StateT s m) where
     liftResourceT = lift . liftResourceT
 
---- Unwrap a 'ResourceT' transformer, and call all registered release actions.
----
---- Note that there is some reference counting involved.
---- If multiple threads are sharing the same collection of resources, only the
---- last call to @runResourceT@ will deallocate the resources.
----
---- Porting note: no effort is made to protect against multi-threading other
---- than the conventional exception-safety, since there is nothing like @mask@
---- in Frege.
+{--
+   Unwrap a 'ResourceT' transformer, and call all registered release actions.
+
+   Note that there is some reference counting involved.
+   If multiple threads are sharing the same collection of resources, only the
+   last call to @runResourceT@ will deallocate the resources.
+
+   Porting note: no effort is made to protect against multi-threading other
+   than the conventional exception-safety, since there is nothing like @mask@
+   in Frege.
+ -}
 runResourceT :: MonadUnliftIO m => ResourceT m a -> m a
 runResourceT (ResourceT.Mk r) = withRunInIO $ \run -> do
     istate <- createInternalState
@@ -100,10 +106,12 @@ runResourceT (ResourceT.Mk r) = withRunInIO $ \run -> do
     stateCleanupChecked Nothing istate
     return res
 
---- Perform some allocation, and automatically register a cleanup action.
----
---- This is identical to calling the allocation and then @register@ing the
---- release action, since there is no @mask@ing in Frege.
+{--
+   Perform some allocation, and automatically register a cleanup action.
+
+   This is identical to calling the allocation and then @register@ing the
+   release action, since there is no @mask@ing in Frege.
+ -}
 allocate :: MonadResource m => IO a -> (a -> IO ()) -> m (ReleaseKey, a)
 allocate a = liftResourceT . allocateRIO a
 
@@ -125,8 +133,10 @@ private register' istate rel = do
     istate.put rm'
     pure key
 
---- Call a release action early, and deregister it from the list of cleanup
---- actions to be performed.
+{--
+   Call a release action early, and deregister it from the list of cleanup
+   actions to be performed.
+ -}
 release :: MonadIO m => ReleaseKey -> m ()
 release (ReleaseKey istate rk) = liftIO $ release' istate rk
     (maybe (return ()) id)
@@ -149,18 +159,22 @@ private release' istate key act = do
     -- can assume that the release action was already called.
     lookupAction ReleaseMapClosed = (ReleaseMapClosed, Nothing)
 
---- Transform the monad a @ResourceT@ lives in. This is most often used to
---- strip or add new transformers to a stack, e.g. to run a @ReaderT@.
----
---- Note that this function is a slight generalization of 'hoist'.
+{--
+   Transform the monad a @ResourceT@ lives in. This is most often used to
+   strip or add new transformers to a stack, e.g. to run a @ReaderT@.
+
+   Note that this function is a slight generalization of 'hoist'.
+ -}
 transResourceT :: (m a -> n b) -> ResourceT m a -> ResourceT n b
 transResourceT f (ResourceT.Mk mx) = ResourceT.Mk (\r -> f (mx r))
 
 
 type IntMap = TreeMap Int
 
---- A lookup key for a specific release action. This value is returned by
---- 'register' and 'allocate', and is passed to 'release'.
+{--
+   A lookup key for a specific release action. This value is returned by
+   'register' and 'allocate', and is passed to 'release'.
+ -}
 data ReleaseKey = ReleaseKey !(IORef ReleaseMap) !Int
 
 type RefCount = Int
@@ -178,19 +192,23 @@ data ReleaseMap
 --- The internal state held by a @ResourceT@ transformer.
 type InternalState = IORef ReleaseMap
 
---- Create a new internal state. This state must be closed with
---- @closeInternalState@. It is your responsibility to ensure exception safety.
---- Caveat emptor!
+{--
+   Create a new internal state. This state must be closed with
+   @closeInternalState@. It is your responsibility to ensure exception safety.
+   Caveat emptor!
+ -}
 createInternalState :: MonadIO m => m InternalState
 createInternalState = liftIO
                     $ IORef.new
                     $ ReleaseMap maxBound (minBound + 1) IntMap.empty
 
---- Clean up a release map, but throw an exception if anything goes wrong in the
---- cleanup handlers.
----
---- Porting note: TODO define what exception is thrown; currently calls 'fail'
---- Porting note: TODO add thread-safety (i.e. atomic IORef ops)
+{--
+   Clean up a release map, but throw an exception if anything goes wrong in the
+   cleanup handlers.
+
+   Porting note: TODO define what exception is thrown; currently calls 'fail'
+   Porting note: TODO add thread-safety (i.e. atomic IORef ops)
+ -}
 stateCleanupChecked
   :: Maybe Exception -- ^ exception that killed the 'ResourceT', if present
   -> IORef ReleaseMap -> IO ()

--- a/src/main/frege/frege/data/ByteString.fr
+++ b/src/main/frege/frege/data/ByteString.fr
@@ -29,26 +29,32 @@ instance Monoid ByteString where
   mempty = empty
   pure native mappend ByteString.mappend_ :: ByteString -> ByteString -> ByteString
 
---- Copies the content of the @ByteString@ to the native @byte[]@ so that
---- it can be used as mutable one.
+{--
+   Copies the content of the @ByteString@ to the native @byte[]@ so that
+   it can be used as mutable one.
+ -}
 native thaw ByteString.thaw_ :: ByteString -> STMutable s (JArray Byte)
 
 --- Copies the content of the mutable @byte[]@ to @ByteString@.
 native freeze ByteString.freeze_ :: Mutable s (JArray Byte) -> ST s ByteString
 
---- Wraps a native @byte[]@ into @ByteString@ without copying.
----
---- note: after applying this function, the wrapped array must *not* be modified!
+{--
+   Wraps a native @byte[]@ into @ByteString@ without copying.
+
+   note: after applying this function, the wrapped array must *not* be modified!
+ -}
 native unsafeFreeze ByteString.unsafeFreeze_ :: Mutable s (JArray Byte) -> ST s ByteString
 
---- Wraps a part of a native @byte[]@ into @ByteString@ without copying.
----
---- note: after applying this function, the wrapped array must *not* be modified!
----
---- Parameters:
---- - the array
---- - the offset
---- - the length
+{--
+   Wraps a part of a native @byte[]@ into @ByteString@ without copying.
+
+   note: after applying this function, the wrapped array must *not* be modified!
+
+   Parameters:
+   - the array
+   - the offset
+   - the length
+ -}
 native unsafeFreezeWith ByteString.unsafeFreezeWith_
   :: Mutable s (JArray Byte) -> Int -> Int -> ST s ByteString
 

--- a/src/main/frege/frege/data/Conduit.fr
+++ b/src/main/frege/frege/data/Conduit.fr
@@ -1,6 +1,8 @@
---- If this is your first time with conduit, you should probably start with
---- the tutorial:
---- <https://github.com/snoyberg/conduit#readme>.
+{--
+   If this is your first time with conduit, you should probably start with
+   the tutorial:
+   <https://github.com/snoyberg/conduit#readme>.
+ -}
 module frege.data.Conduit where
 
 import frege.control.monad.io.Unlift (MonadUnliftIO, withRunInIO)
@@ -20,11 +22,13 @@ import frege.data.conduit.internal.Pipe
   )
 import frege.data.wrapper.Identity (Identity)
 
---- Core datatype of the conduit package. This type represents a general
---- component which can consume a stream of input values @i@, produce a stream
---- of output values @o@, perform actions in the @m@ monad, and produce a final
---- result @r@. The type synonyms provided here are simply wrappers around this
---- type.
+{--
+   Core datatype of the conduit package. This type represents a general
+   component which can consume a stream of input values @i@, produce a stream
+   of output values @o@, perform actions in the @m@ monad, and produce a final
+   result @r@. The type synonyms provided here are simply wrappers around this
+   type.
+ -}
 data ConduitT i o m r = ConduitT
     { run :: forall b.
              (r -> Pipe i i o () m b) -> Pipe i i o () m b
@@ -55,49 +59,57 @@ instance Monoid (ConduitT i o m ()) where
 runConduit :: Monad m => ConduitT () Void m r -> m r
 runConduit (ConduitT p) = runPipe $ injectLeftovers $ p Done
 
---- Run a pure pipeline until processing completes, i.e. a pipeline with
---- @Identity@ as the base monad. This is equivalent to
---- @Identity.run . runConduit@.
+{--
+   Run a pure pipeline until processing completes, i.e. a pipeline with
+   @Identity@ as the base monad. This is equivalent to
+   @Identity.run . runConduit@.
+ -}
 runConduitPure :: ConduitT () Void Identity r -> r
 runConduitPure = Identity.run . runConduit
 
---- Run a pipeline which acquires resources with @ResourceT@, and
---- then run the @ResourceT@ transformer. This is equivalent to
---- @runResourceT . runConduit@.
+{--
+   Run a pipeline which acquires resources with @ResourceT@, and
+   then run the @ResourceT@ transformer. This is equivalent to
+   @runResourceT . runConduit@.
+ -}
 runConduitRes :: MonadUnliftIO m => ConduitT () Void (ResourceT m) r -> m r
 runConduitRes = runResourceT . runConduit
 
---- Named function synonym for '.|'.
----
---- Equivalent to '.|'.
+{--
+   Named function synonym for '.|'.
+
+   Equivalent to '.|'.
+ -}
 fuse :: Monad m => ConduitT a b m () -> ConduitT b c m r -> ConduitT a c m r
 fuse = (.|)
 
---- Combine two @Conduit@s together into a new @Conduit@ (aka 'fuse').
----
---- Output from the upstream (left) conduit will be fed into the
---- downstream (right) conduit. Processing will terminate when
---- downstream (right) returns.
---- Leftover data returned from the right @Conduit@ will be discarded.
----
---- Equivalent to 'fuse' and '=$=', however the latter is deprecated and will
---- be removed in a future version.
----
---- Note that, while this operator looks like categorical composition
---- (from "Control.Category"), there are a few reasons it's different:
----
---- * The position of the type parameters to 'ConduitT' do not
----   match. We would need to change @ConduitT i o m r@ to @ConduitT r
----   m i o@, which would preclude a 'Monad' or 'MonadTrans' instance.
----
---- * The result value from upstream and downstream are allowed to
----   differ between upstream and downstream. In other words, we would
----   need the type signature here to look like @ConduitT a b m r ->
----   ConduitT b c m r -> ConduitT a c m r@.
----
---- * Due to leftovers, we do not have a left identity in Conduit. This
----   can be achieved with the underlying @Pipe@ datatype, but this is
----   not generally recommended. See <https://stackoverflow.com/a/15263700>.
+{--
+   Combine two @Conduit@s together into a new @Conduit@ (aka 'fuse').
+
+   Output from the upstream (left) conduit will be fed into the
+   downstream (right) conduit. Processing will terminate when
+   downstream (right) returns.
+   Leftover data returned from the right @Conduit@ will be discarded.
+
+   Equivalent to 'fuse' and '=$=', however the latter is deprecated and will
+   be removed in a future version.
+
+   Note that, while this operator looks like categorical composition
+   (from "Control.Category"), there are a few reasons it's different:
+
+   * The position of the type parameters to 'ConduitT' do not
+     match. We would need to change @ConduitT i o m r@ to @ConduitT r
+     m i o@, which would preclude a 'Monad' or 'MonadTrans' instance.
+
+   * The result value from upstream and downstream are allowed to
+     differ between upstream and downstream. In other words, we would
+     need the type signature here to look like @ConduitT a b m r ->
+     ConduitT b c m r -> ConduitT a c m r@.
+
+   * Due to leftovers, we do not have a left identity in Conduit. This
+     can be achieved with the underlying @Pipe@ datatype, but this is
+     not generally recommended. See <https://stackoverflow.com/a/15263700>.
+ -}
 (.|) :: Monad m => ConduitT a b m ()
                 -> ConduitT b c m r
                 -> ConduitT a c m r
@@ -124,23 +136,27 @@ ConduitT left0 .| ConduitT right0 = ConduitT (\rest ->
      in goRight (left0 Done) (right0 Done)
     )
 
---- Fuse two @ConduitT@s together, and provide the return value of both. Note
---- that this will force the entire upstream @ConduitT@ to be run to produce the
---- result value, even if the downstream terminates early.
+{--
+   Fuse two @ConduitT@s together, and provide the return value of both. Note
+   that this will force the entire upstream @ConduitT@ to be run to produce the
+   result value, even if the downstream terminates early.
+ -}
 fuseBoth :: Monad m => ConduitT a b m r1 -> ConduitT b c m r2 -> ConduitT a c m (r1, r2)
 fuseBoth (ConduitT up) (ConduitT down) =
     ConduitT (pipeL (up Done) (withUpstream $ generalizeUpstream $ down Done) >>=)
 
---- Like 'fuseBoth', but does not force consumption of the @Producer@.
---- In the case that the @Producer@ terminates, the result value is
---- provided as a @Just@ value. If it does not terminate, then a
---- @Nothing@ value is returned.
----
---- One thing to note here is that "termination" here only occurs if the
---- @Producer@ actually yields a @Nothing@ value. For example, with the
---- @Producer@ @mapM_ yield [1..5]@, if five values are requested, the
---- @Producer@ has not yet terminated. Termination only occurs when the
---- sixth value is awaited for and the @Producer@ signals termination.
+{--
+   Like 'fuseBoth', but does not force consumption of the @Producer@.
+   In the case that the @Producer@ terminates, the result value is
+   provided as a @Just@ value. If it does not terminate, then a
+   @Nothing@ value is returned.
+
+   One thing to note here is that "termination" here only occurs if the
+   @Producer@ actually yields a @Nothing@ value. For example, with the
+   @Producer@ @mapM_ yield [1..5]@, if five values are requested, the
+   @Producer@ has not yet terminated. Termination only occurs when the
+   sixth value is awaited for and the @Producer@ signals termination.
+ -}
 fuseBothMaybe :: Monad m
               => ConduitT a b m r1
               -> ConduitT b c m r2
@@ -156,54 +172,66 @@ fuseBothMaybe (ConduitT up) (ConduitT down) =
         (\u -> go (Just u) (c ()))
     go mup (Leftover p i) = Leftover (go mup p) i
 
---- Same as @fuseBoth@, but ignore the return value from the downstream
---- @Conduit@. Same caveats of forced consumption apply.
+{--
+   Same as @fuseBoth@, but ignore the return value from the downstream
+   @Conduit@. Same caveats of forced consumption apply.
+ -}
 fuseUpstream :: Monad m => ConduitT a b m r -> ConduitT b c m () -> ConduitT a c m r
 fuseUpstream up down = fmap fst (fuseBoth up down)
 
---- Wait for a single input value from upstream. If no data is available,
---- returns @Nothing@. Once @await@ returns @Nothing@, subsequent calls will
---- also return @Nothing@.
+{--
+   Wait for a single input value from upstream. If no data is available,
+   returns @Nothing@. Once @await@ returns @Nothing@, subsequent calls will
+   also return @Nothing@.
+ -}
 await :: Monad m => ConduitT i o m (Maybe i)
 await = ConduitT (\f -> NeedInput (f . Just) (const $ f Nothing))
 
---- Provide a single piece of leftover input to be consumed by the next
---- component in the current monadic binding.
----
---- /Note/: it is highly encouraged to only return leftover values from input
---- already consumed from upstream.
+{--
+   Provide a single piece of leftover input to be consumed by the next
+   component in the current monadic binding.
+
+   /Note/: it is highly encouraged to only return leftover values from input
+   already consumed from upstream.
+ -}
 leftover :: i -> ConduitT i o m ()
 leftover i = ConduitT (\rest -> Leftover (rest ()) i)
 
---- Send a value downstream to the next component to consume. If the
---- downstream component terminates, this call will never return control.
+{--
+   Send a value downstream to the next component to consume. If the
+   downstream component terminates, this call will never return control.
+ -}
 yield :: Monad m => o -> ConduitT i o m ()
 yield o = ConduitT (\rest -> HaveOutput (rest ()) o)
 
---- Wait for input forever, calling the given inner component for each piece of
---- new input.
----
---- This function is provided as a convenience for the common pattern of
---- @await@ing input, checking if it's @Just@ and then looping.
+{--
+   Wait for input forever, calling the given inner component for each piece of
+   new input.
+
+   This function is provided as a convenience for the common pattern of
+   @await@ing input, checking if it's @Just@ and then looping.
+ -}
 awaitForever :: Monad m => (i -> ConduitT i o m r) -> ConduitT i o m ()
 awaitForever f = ConduitT (\rest ->
   let go = NeedInput (\i -> unConduitT (f i) (const go)) rest
    in go)
 
---- Bracket a conduit computation between allocation and release of a
---- resource. Two guarantees are given about resource finalization:
----
---- 1. It will be /prompt/. The finalization will be run as early as possible.
----
---- 2. It is exception safe. Due to usage of @resourcet@, the finalization will
---- be run in the event of any exceptions.
----
---- Parameters:
---- - computation to run first (\"acquire resource\")
---- - computation to run last (\"release resource\")
---- - computation to run in-between
---- Returns:
---- - returns the value from the in-between computation
+{--
+   Bracket a conduit computation between allocation and release of a
+   resource. Two guarantees are given about resource finalization:
+
+   1. It will be /prompt/. The finalization will be run as early as possible.
+
+   2. It is exception safe. Due to usage of @resourcet@, the finalization will
+   be run in the event of any exceptions.
+
+   Parameters:
+   - computation to run first (\"acquire resource\")
+   - computation to run last (\"release resource\")
+   - computation to run in-between
+   Returns:
+   - returns the value from the in-between computation
+ -}
 bracketP :: MonadResource m => IO a -> (a -> IO ()) -> (a -> ConduitT i o m r)
                             -> ConduitT i o m r
 bracketP alloc free inside = ConduitT (\rest -> do
@@ -214,18 +242,18 @@ bracketP alloc free inside = ConduitT (\rest -> do
   )
 
 {--
- - Catch all exceptions thrown by the current component of the pipeline.
- -
- - Note: this will /not/ catch exceptions thrown by other components! For
- - example, if an exception is thrown in a @Source@ feeding to a @Sink@, and
- - the @Sink@ uses @catchC@, the exception will /not/ be caught.
- -
- - Due to this behavior (as well as lack of async exception safety), you should
- - not try to implement combinators such as @onException@ in terms of this
- - primitive function.
- -
- - Note also that the exception handling will /not/ be applied to any finalizers
- - generated by this conduit.
+   Catch all exceptions thrown by the current component of the pipeline.
+
+   Note: this will /not/ catch exceptions thrown by other components! For
+   example, if an exception is thrown in a @Source@ feeding to a @Sink@, and
+   the @Sink@ uses @catchC@, the exception will /not/ be caught.
+
+   Due to this behavior (as well as lack of async exception safety), you should
+   not try to implement combinators such as @onException@ in terms of this
+   primitive function.
+
+   Note also that the exception handling will /not/ be applied to any finalizers
+   generated by this conduit.
  -}
 catchC :: (MonadUnliftIO m, Exceptional e)
        => ConduitT i o m r
@@ -247,19 +275,21 @@ handleC :: (MonadUnliftIO m, Exceptional e)
 handleC = flip catchC
 
 {--
- - A version of Haskell's @try@ for use within a pipeline. See the comments in
- - @catchC@ for more details.
+   A version of Haskell's @try@ for use within a pipeline. See the comments in
+   @catchC@ for more details.
  -}
 tryC :: (MonadUnliftIO m, Exceptional e)
      => ConduitT i o m r
      -> ConduitT i o m (Either e r)
 tryC c = fmap Right c `catchC` (return . Left)
 
---- Apply a function to all the output values of a @ConduitT@.
----
---- This mimics the behavior of `fmap` for a `Source` and `Conduit` in pre-0.4
---- days. It can also be simulated by fusing with the @map@ conduit from
---- "frege.data.conduit.Combinators".
+{--
+   Apply a function to all the output values of a @ConduitT@.
+
+   This mimics the behavior of `fmap` for a `Source` and `Conduit` in pre-0.4
+   days. It can also be simulated by fusing with the @map@ conduit from
+   "frege.data.conduit.Combinators".
+ -}
 mapOutput :: Monad m => (o1 -> o2) -> ConduitT i o1 m r -> ConduitT i o2 m r
 mapOutput f (ConduitT c0) = ConduitT (\rest -> let
     go (HaveOutput p o) = HaveOutput (go p) (f o)
@@ -269,10 +299,12 @@ mapOutput f (ConduitT c0) = ConduitT (\rest -> let
     go (Leftover p i) = Leftover (go p) i
     in go (c0 Done))
 
---- Combines two sinks. The new sink will complete when both input sinks have
---- completed.
----
---- Any leftovers are discarded.
+{--
+   Combines two sinks. The new sink will complete when both input sinks have
+   completed.
+
+   Any leftovers are discarded.
+ -}
 zipSinks :: Monad m => ConduitT i Void m r -> ConduitT i Void m r' -> ConduitT i Void m (r, r')
 zipSinks (ConduitT x0) (ConduitT y0) = ConduitT (\rest -> let
     Leftover _  i    >< _                = absurd i
@@ -289,8 +321,10 @@ zipSinks (ConduitT x0) (ConduitT y0) = ConduitT (\rest -> let
     _ >< _ = error "Never happens; The pattern is indeed exhaustive, but the compiler reports otherwise"
     in injectLeftovers (x0 Done) >< injectLeftovers (y0 Done))
 
---- Combines two sources. The new source will stop producing once either
---- source has been exhausted.
+{--
+   Combines two sources. The new source will stop producing once either
+   source has been exhausted.
+ -}
 zipSources :: Monad m => ConduitT () a m () -> ConduitT () b m () -> ConduitT () (a, b) m ()
 zipSources (ConduitT left0) (ConduitT right0) = ConduitT (\rest -> let
     go (Leftover left ()) right = go left right
@@ -309,8 +343,10 @@ zipSources (ConduitT left0) (ConduitT right0) = ConduitT (\rest -> let
     go _ _ = error "Never happens; The pattern is indeed exhaustive, but the compiler reports otherwise"
     in go (left0 Done) (right0 Done))
 
---- Combines two sources. The new source will stop producing once either
---- source has been exhausted.
+{--
+   Combines two sources. The new source will stop producing once either
+   source has been exhausted.
+ -}
 zipSourcesApp :: Monad m => ConduitT () (a -> b) m () -> ConduitT () a m () -> ConduitT () b m ()
 zipSourcesApp (ConduitT left0) (ConduitT right0) = ConduitT (\rest -> let
     go (Leftover left ()) right = go left right
@@ -351,10 +387,12 @@ zipConduitApp (ConduitT left0) (ConduitT right0) = ConduitT (\rest -> let
     go _ _ = error "Never happens; The pattern is indeed exhaustive, but the compiler reports otherwise"
   in go (injectLeftovers $ left0 Done) (injectLeftovers $ right0 Done))
 
---- A wrapper for defining an 'Applicative' instance for 'Source's which allows
---- to combine sources together, generalizing 'zipSources'. A combined source
---- will take input yielded from each of its @Source@s until any of them stop
---- producing output.
+{--
+   A wrapper for defining an 'Applicative' instance for 'Source's which allows
+   to combine sources together, generalizing 'zipSources'. A combined source
+   will take input yielded from each of its @Source@s until any of them stop
+   producing output.
+ -}
 data ZipSource (m :: * -> *) o = ZipSource { get :: ConduitT () o m () }
 
 instance Monad m => Functor (ZipSource m) where
@@ -363,26 +401,28 @@ instance Monad m => Applicative (ZipSource m) where
     pure = ZipSource . forever . yield
     (ZipSource f) <*> (ZipSource x) = ZipSource $ zipSourcesApp f x
 
---- A wrapper for defining an 'Applicative' instance for 'Sink's which allows
---- to combine sinks together, generalizing 'zipSinks'. A combined sink
---- distributes the input to all its participants and when all finish, produces
---- the result. This allows to define functions like
----
---- @
---- sequenceSinks :: (Monad m)
----           => [Sink i m r] -> Sink i m [r]
---- sequenceSinks = getZipSink . sequenceA . fmap ZipSink
---- @
----
---- Note that the standard 'Applicative' instance for conduits works
---- differently. It feeds one sink with input until it finishes, then switches
---- to another, etc., and at the end combines their results.
----
---- This newtype is in fact a type constrained version of 'ZipConduit', and has
---- the same behavior. It's presented as a separate type since (1) it
---- historically predates @ZipConduit@, and (2) the type constraining can make
---- your code clearer (and thereby make your error messages more easily
---- understood).
+{--
+   A wrapper for defining an 'Applicative' instance for 'Sink's which allows
+   to combine sinks together, generalizing 'zipSinks'. A combined sink
+   distributes the input to all its participants and when all finish, produces
+   the result. This allows to define functions like
+
+   @
+   sequenceSinks :: (Monad m)
+             => [Sink i m r] -> Sink i m [r]
+   sequenceSinks = getZipSink . sequenceA . fmap ZipSink
+   @
+
+   Note that the standard 'Applicative' instance for conduits works
+   differently. It feeds one sink with input until it finishes, then switches
+   to another, etc., and at the end combines their results.
+
+   This newtype is in fact a type constrained version of 'ZipConduit', and has
+   the same behavior. It's presented as a separate type since (1) it
+   historically predates @ZipConduit@, and (2) the type constraining can make
+   your code clearer (and thereby make your error messages more easily
+   understood).
+ -}
 data ZipSink i (m :: * -> *) r = ZipSink { get :: ConduitT i Void m r }
 
 instance Monad m => Functor (ZipSink i m) where
@@ -392,25 +432,27 @@ instance Monad m => Applicative (ZipSink i m) where
     (ZipSink f) <*> (ZipSink x) =
         ZipSink $ liftM (uncurry ($)) $ zipSinks f x
 
---- Provides an alternative @Applicative@ instance for @ConduitT@. In this instance,
---- every incoming value is provided to all @ConduitT@s, and output is coalesced together.
---- Leftovers from individual @ConduitT@s will be used within that component, and then discarded
---- at the end of their computation. Output and finalizers will both be handled in a left-biased manner.
----
---- As an example, take the following program:
----
---- @
---- main :: IO ()
---- main = do
----     let src = mapM_ yield [1..3 :: Int]
----         conduit1 = CL.map (+1)
----         conduit2 = CL.concatMap (replicate 2)
----         conduit = getZipConduit $ ZipConduit conduit1 <* ZipConduit conduit2
----         sink = CL.mapM_ print
----     src $$ conduit =$ sink
---- @
----
---- It will produce the output: 2, 1, 1, 3, 2, 2, 4, 3, 3
+{--
+   Provides an alternative @Applicative@ instance for @ConduitT@. In this instance,
+   every incoming value is provided to all @ConduitT@s, and output is coalesced together.
+   Leftovers from individual @ConduitT@s will be used within that component, and then discarded
+   at the end of their computation. Output and finalizers will both be handled in a left-biased manner.
+
+   As an example, take the following program:
+
+   @
+   main :: IO ()
+   main = do
+       let src = mapM_ yield [1..3 :: Int]
+           conduit1 = CL.map (+1)
+           conduit2 = CL.concatMap (replicate 2)
+           conduit = getZipConduit $ ZipConduit conduit1 <* ZipConduit conduit2
+           sink = CL.mapM_ print
+       src $$ conduit =$ sink
+   @
+
+   It will produce the output: 2, 1, 1, 3, 2, 2, 4, 3, 3
+ -}
 data ZipConduit i o (m :: * -> *) r = ZipConduit { get :: ConduitT i o m r }
 
 --- Porting note: was @deriving Functor@

--- a/src/main/frege/frege/data/Conduit.fr
+++ b/src/main/frege/frege/data/Conduit.fr
@@ -97,16 +97,16 @@ fuse = (.|)
    Note that, while this operator looks like categorical composition
    (from "Control.Category"), there are a few reasons it's different:
 
-   * The position of the type parameters to 'ConduitT' do not
+   - The position of the type parameters to 'ConduitT' do not
      match. We would need to change @ConduitT i o m r@ to @ConduitT r
      m i o@, which would preclude a 'Monad' or 'MonadTrans' instance.
 
-   * The result value from upstream and downstream are allowed to
+   - The result value from upstream and downstream are allowed to
      differ between upstream and downstream. In other words, we would
      need the type signature here to look like @ConduitT a b m r ->
      ConduitT b c m r -> ConduitT a c m r@.
 
-   * Due to leftovers, we do not have a left identity in Conduit. This
+   - Due to leftovers, we do not have a left identity in Conduit. This
      can be achieved with the underlying @Pipe@ datatype, but this is
      not generally recommended. See <https://stackoverflow.com/a/15263700>.
  -}
@@ -407,11 +407,9 @@ instance Monad m => Applicative (ZipSource m) where
    distributes the input to all its participants and when all finish, produces
    the result. This allows to define functions like
 
-   @
-   sequenceSinks :: (Monad m)
-             => [Sink i m r] -> Sink i m [r]
-   sequenceSinks = getZipSink . sequenceA . fmap ZipSink
-   @
+   > sequenceSinks :: (Monad m)
+   >           => [Sink i m r] -> Sink i m [r]
+   > sequenceSinks = getZipSink . sequenceA . fmap ZipSink
 
    Note that the standard 'Applicative' instance for conduits works
    differently. It feeds one sink with input until it finishes, then switches
@@ -440,16 +438,14 @@ instance Monad m => Applicative (ZipSink i m) where
 
    As an example, take the following program:
 
-   @
-   main :: IO ()
-   main = do
-       let src = mapM_ yield [1..3 :: Int]
-           conduit1 = CL.map (+1)
-           conduit2 = CL.concatMap (replicate 2)
-           conduit = getZipConduit $ ZipConduit conduit1 <* ZipConduit conduit2
-           sink = CL.mapM_ print
-       src $$ conduit =$ sink
-   @
+   > main :: IO ()
+   > main = do
+   >     let src = mapM_ yield [1..3 :: Int]
+   >         conduit1 = CL.map (+1)
+   >         conduit2 = CL.concatMap (replicate 2)
+   >         conduit = getZipConduit $ ZipConduit conduit1 <* ZipConduit conduit2
+   >         sink = CL.mapM_ print
+   >     src $$ conduit =$ sink
 
    It will produce the output: 2, 1, 1, 3, 2, 2, 4, 3, 3
  -}

--- a/src/main/frege/frege/data/Void.fr
+++ b/src/main/frege/frege/data/Void.fr
@@ -1,22 +1,26 @@
---- Ported from Haskell base library
---- Copyright   :  (C) 2008-2014 Edward Kmett
---- License     :  BSD-style (see the file libraries/base/LICENSE)
+{--
+   Ported from Haskell base library
+   Copyright   :  (C) 2008-2014 Edward Kmett
+   License     :  BSD-style (see the file libraries/base/LICENSE)
+ -}
 -- TODO split into subproject
 module frege.data.Void where
 
 --- Uninhabited data type
 data Void
 
---- nowarn: diverge
---- Since 'Void' values logically don't exist, this witnesses the
---- logical reasoning tool of \"ex falso quodlibet\".
----
---- > >>> let x :: Either Void Int; x = Right 5
---- > >>> :{
---- > case x of
---- >      Right r -> r
---- >      Left l  -> absurd l
---- > :}
---- > 5
+{--
+   nowarn: diverge
+   Since 'Void' values logically don't exist, this witnesses the
+   logical reasoning tool of \"ex falso quodlibet\".
+
+   > >>> let x :: Either Void Int; x = Right 5
+   > >>> :{
+   > case x of
+   >      Right r -> r
+   >      Left l  -> absurd l
+   > :}
+   > 5
+ -}
 absurd :: Void -> a
 absurd = absurd

--- a/src/main/frege/frege/data/conduit/Combinators.fr
+++ b/src/main/frege/frege/data/conduit/Combinators.fr
@@ -2,11 +2,11 @@
    Since some type classes don't exist in Frege yet, some functions have
    different types as follows:
 
-   * For chunked operations (@fooE@), specialized functions are provided.
+   - For chunked operations (@fooE@), specialized functions are provided.
      Some expects lists only, some can accept general @Foldable@s.
      Please consult type signature for each function.
-   * Also, String variants are added (@fooStr@ for each @fooE@)
-   * Moreover, @ByteString@ (immutable byte[]) variants are added (@fooBS@).
+   - Also, String variants are added (@fooStr@ for each @fooE@)
+   - Moreover, @ByteString@ (immutable byte[]) variants are added (@fooBS@).
  -}
 module frege.data.conduit.Combinators where
 

--- a/src/main/frege/frege/data/conduit/Combinators.fr
+++ b/src/main/frege/frege/data/conduit/Combinators.fr
@@ -1,11 +1,13 @@
---- Since some type classes don't exist in Frege yet, some functions have
---- different types as follows:
----
---- * For chunked operations (@fooE@), specialized functions are provided.
----   Some expects lists only, some can accept general @Foldable@s.
----   Please consult type signature for each function.
---- * Also, String variants are added (@fooStr@ for each @fooE@)
---- * Moreover, @ByteString@ (immutable byte[]) variants are added (@fooBS@).
+{--
+   Since some type classes don't exist in Frege yet, some functions have
+   different types as follows:
+
+   * For chunked operations (@fooE@), specialized functions are provided.
+     Some expects lists only, some can accept general @Foldable@s.
+     Please consult type signature for each function.
+   * Also, String variants are added (@fooStr@ for each @fooE@)
+   * Moreover, @ByteString@ (immutable byte[]) variants are added (@fooBS@).
+ -}
 module frege.data.conduit.Combinators where
 
 import frege.Prelude hiding
@@ -65,14 +67,20 @@ import frege.java.Util (ArrayList)
 
 type FilePath = String
 
---- nowarn: not supposed to change
---- For compatibility with pre-3.25 Frege, where this is declared as (deprecated) @mutable native@
+{--
+   nowarn: not supposed to change
+   For compatibility with pre-3.25 Frege, where this is declared as (deprecated) @mutable native@
+ -}
 native systemIn  "System.in"  :: MutableIO FI.InputStream
---- nowarn: not supposed to change
---- For compatibility with pre-3.25 Frege, where this is declared as (deprecated) @mutable native@
+{--
+   nowarn: not supposed to change
+   For compatibility with pre-3.25 Frege, where this is declared as (deprecated) @mutable native@
+ -}
 native systemOut "System.out" :: MutableIO FO.OutputStream
---- nowarn: not supposed to change
---- For compatibility with pre-3.25 Frege, where this is declared as (deprecated) @mutable native@
+{--
+   nowarn: not supposed to change
+   For compatibility with pre-3.25 Frege, where this is declared as (deprecated) @mutable native@
+ -}
 native systemErr "System.err" :: MutableIO FO.OutputStream
 
 --- Yield each of the values contained by the given @Foldable@.
@@ -97,11 +105,13 @@ unfold f =
             Just (a, seed') -> yield a >> go seed'
             Nothing -> pure ()
 
---- Enumerate from a value to a final value, inclusive, via 'succ'.
----
---- This is generally more efficient than using @Prelude@\'s @enumFromTo@ and
---- combining with @sourceList@ since this avoids any intermediate data
---- structures.
+{--
+   Enumerate from a value to a final value, inclusive, via 'succ'.
+
+   This is generally more efficient than using @Prelude@\'s @enumFromTo@ and
+   combining with @sourceList@ since this avoids any intermediate data
+   structures.
+ -}
 enumFromTo :: (Monad m, Enum a, Ord a) => a -> a -> ConduitT i a m ()
 enumFromTo x0 y =
     loop x0
@@ -134,8 +144,10 @@ replicate cnt0 a =
 repeatM :: Monad m => m a -> ConduitT i a m ()
 repeatM m = forever $ lift m >>= yield
 
---- Repeatedly run the given action and yield all values it produces, until
---- the provided predicate returns @False@.
+{--
+   Repeatedly run the given action and yield all values it produces, until
+   the provided predicate returns @False@.
+ -}
 repeatWhileM :: Monad m => m a -> (a -> Bool) -> ConduitT i a m ()
 repeatWhileM m f =
     loop
@@ -161,9 +173,11 @@ sourceFile fp =
         FI.closeFile
         sourceInputStream
 
---- Stream the content of an 'InputStream' as binary data. Note that this
---- function will /not/ automatically close the @InputStream@ when procefssing
---- completes, since it did not acquire the @InputStream@ in the first place.
+{--
+   Stream the content of an 'InputStream' as binary data. Note that this
+   function will /not/ automatically close the @InputStream@ when procefssing
+   completes, since it did not acquire the @InputStream@ in the first place.
+ -}
 sourceInputStream :: MonadIO m
                   => MutableIO FI.InputStream
                   -> ConduitT i ByteString m ()
@@ -180,8 +194,10 @@ sourceInputStream is =
 stdin :: MonadIO m => ConduitT i ByteString m ()
 stdin = sourceInputStream systemIn
 
---- Like 'IO.withBinaryFile' in Haskell, but provides a source to read bytes
---- from.
+{--
+   Like 'IO.withBinaryFile' in Haskell, but provides a source to read bytes
+   from.
+ -}
 withSourceFile
   :: (MonadUnliftIO m, MonadIO n)
   => FilePath
@@ -192,15 +208,17 @@ withSourceFile fp inner =
   FI.openFile fp >>= \is ->
   (run . inner . sourceInputStream) is `finally` FI.closeFile is
 
---- Ignore a certain number of values in the stream.
----
---- Note: since this function doesn't produce anything, you probably want to
---- use it with ('>>') instead of directly plugging it into a pipeline:
----
---- > >>> runConduit $ yieldMany [1..5] .| drop 2 .| sinkList
---- > []
---- > >>> runConduit $ yieldMany [1..5] .| (drop 2 >> sinkList)
---- > [3,4,5]
+{--
+   Ignore a certain number of values in the stream.
+
+   Note: since this function doesn't produce anything, you probably want to
+   use it with ('>>') instead of directly plugging it into a pipeline:
+
+   > >>> runConduit $ yieldMany [1..5] .| drop 2 .| sinkList
+   > []
+   > >>> runConduit $ yieldMany [1..5] .| (drop 2 >> sinkList)
+   > [3,4,5]
+ -}
 drop :: Monad m => Int -> ConduitT a o m()
 drop =
     loop
@@ -208,10 +226,12 @@ drop =
     loop i | i <= 0 = return ()
     loop count = await >>= maybe (return ()) (\_ -> loop (count - 1))
 
---- Drop a certain number of elements from a chunked stream.
----
---- Note: you likely want to use it with monadic composition. See the docs
---- for 'drop'.
+{--
+   Drop a certain number of elements from a chunked stream.
+
+   Note: you likely want to use it with monadic composition. See the docs
+   for 'drop'.
+ -}
 dropE :: (Monad m, Foldable f, ListView f) => Int -> ConduitT (f a) o m ()
 dropE =
     loop
@@ -227,10 +247,12 @@ dropE =
         (x, y) = Seq.splitAt i sq
         i' = i - fromIntegral (Seq.olength x)
 
---- Drop a certain number of Chars from a String stream.
----
---- Note: you likely want to use it with monadic composition. See the docs
---- for 'drop'.
+{--
+   Drop a certain number of Chars from a String stream.
+
+   Note: you likely want to use it with monadic composition. See the docs
+   for 'drop'.
+ -}
 dropStr :: Monad m => Int -> ConduitT String o m ()
 dropStr =
     loop
@@ -246,10 +268,12 @@ dropStr =
         (x, y) = StrSeq.splitAt i sq
         i' = i - fromIntegral (StrSeq.olength x)
 
---- Drop a certain number of Bytes from a ByteString stream.
----
---- Note: you likely want to use it with monadic composition. See the docs
---- for 'drop'.
+{--
+   Drop a certain number of Bytes from a ByteString stream.
+
+   Note: you likely want to use it with monadic composition. See the docs
+   for 'drop'.
+ -}
 dropBS :: Monad m => Int -> ConduitT ByteString o m ()
 dropBS =
     loop
@@ -265,10 +289,12 @@ dropBS =
         (x, y) = BSSeq.splitAt i sq
         i' = i - fromIntegral (BSSeq.olength x)
 
---- Drop all values which match the given predicate.
----
---- Note: you likely want to use it with monadic composition. See the docs
---- for 'drop'.
+{--
+   Drop all values which match the given predicate.
+
+   Note: you likely want to use it with monadic composition. See the docs
+   for 'drop'.
+ -}
 dropWhile :: Monad m => (a -> Bool) -> ConduitT a o m ()
 dropWhile f =
     loop
@@ -276,10 +302,12 @@ dropWhile f =
     loop = await >>= maybe (return ()) go
     go x = if f x then loop else leftover x
 
---- Drop all elements in the chunked stream which match the given predicate.
----
---- Note: you likely want to use it with monadic composition. See the docs
---- for 'drop'.
+{--
+   Drop all elements in the chunked stream which match the given predicate.
+
+   Note: you likely want to use it with monadic composition. See the docs
+   for 'drop'.
+ -}
 dropWhileE :: (Monad m) => (a -> Bool) -> ConduitT [a] o m ()
 dropWhileE f =
     loop
@@ -291,10 +319,12 @@ dropWhileE f =
       where
         x = Seq.dropWhile f sq
 
---- Drop all elements in the String stream which match the given predicate.
----
---- Note: you likely want to use it with monadic composition. See the docs
---- for 'drop'.
+{--
+   Drop all elements in the String stream which match the given predicate.
+
+   Note: you likely want to use it with monadic composition. See the docs
+   for 'drop'.
+ -}
 dropWhileStr :: Monad m => (Char -> Bool) -> ConduitT String o m ()
 dropWhileStr f =
     loop
@@ -306,10 +336,12 @@ dropWhileStr f =
       where
         x = StrSeq.dropWhile f sq
 
---- Drop all elements in the ByteString stream which match the given predicate.
----
---- Note: you likely want to use it with monadic composition. See the docs
---- for 'drop'.
+{--
+   Drop all elements in the ByteString stream which match the given predicate.
+
+   Note: you likely want to use it with monadic composition. See the docs
+   for 'drop'.
+ -}
 dropWhileBS :: Monad m => (Byte -> Bool) -> ConduitT ByteString o m ()
 dropWhileBS f =
     loop
@@ -321,9 +353,11 @@ dropWhileBS f =
       where
         x = BSSeq.dropWhile f sq
 
---- Monoidally combine all values in the stream.
----
---- Porting note: this is NOT Conduit.List.fold. It is 'foldl'.
+{--
+   Monoidally combine all values in the stream.
+
+   Porting note: this is NOT Conduit.List.fold. It is 'foldl'.
+ -}
 fold :: (Monad m, Monoid a) => ConduitT a o m a
 fold = foldMap id
 
@@ -331,17 +365,21 @@ fold = foldMap id
 foldE :: (Monad m, Foldable f, Monoid a) => ConduitT (f a) o m a
 foldE = foldl (\accum mono -> accum `mappend` Seq.ofoldMap id mono) mempty
 
---- A strict left fold.
----
---- Porting note: corresponds to Conduit.List.fold
+{--
+   A strict left fold.
+
+   Porting note: corresponds to Conduit.List.fold
+ -}
 foldl :: Monad m => (a -> b -> a) -> a -> ConduitT b o m a
 foldl f =
     loop
   where
     loop !accum = await >>= maybe (return accum) (loop . f accum)
 
---- A strict left fold with no starting value.  Returns 'Nothing'
---- when the stream is empty.
+{--
+   A strict left fold with no starting value.  Returns 'Nothing'
+   when the stream is empty.
+ -}
 foldl1 :: Monad m => (a -> a -> a) -> ConduitT a o m (Maybe a)
 foldl1 f =
     await >>= maybe (return Nothing) loop
@@ -376,83 +414,107 @@ foldMapStr f = foldMap (StrSeq.ofoldMap f)
 foldMapBS :: (Monad m, Monoid w) => (Byte -> w) -> ConduitT ByteString o m w
 foldMapBS f = foldMap (BSSeq.ofoldMap f)
 
---- Check that all values in the stream return True.
----
---- Subject to shortcut logic: at the first False, consumption of the stream
---- will stop.
+{--
+   Check that all values in the stream return True.
+
+   Subject to shortcut logic: at the first False, consumption of the stream
+   will stop.
+ -}
 all :: Monad m => (a -> Bool) -> ConduitT a o m Bool
 all f = fmap isNothing $ find (not . f)
 
---- Check that all elements in the chunked stream return True.
----
---- Subject to shortcut logic: at the first False, consumption of the stream
---- will stop.
+{--
+   Check that all elements in the chunked stream return True.
+
+   Subject to shortcut logic: at the first False, consumption of the stream
+   will stop.
+ -}
 allE :: (Monad m, Foldable f) => (a -> Bool) -> ConduitT (f a) o m Bool
 allE f = all (Seq.oall f)
 
---- Check that all Chars in the String stream return True.
----
---- Subject to shortcut logic: at the first False, consumption of the stream
---- will stop.
+{--
+   Check that all Chars in the String stream return True.
+
+   Subject to shortcut logic: at the first False, consumption of the stream
+   will stop.
+ -}
 allStr :: Monad m => (Char -> Bool) -> ConduitT String o m Bool
 allStr f = all (StrSeq.oall f)
 
---- Check that all Bytes in the ByteString stream return True.
----
---- Subject to shortcut logic: at the first False, consumption of the stream
---- will stop.
+{--
+   Check that all Bytes in the ByteString stream return True.
+
+   Subject to shortcut logic: at the first False, consumption of the stream
+   will stop.
+ -}
 allBS :: Monad m => (Byte -> Bool) -> ConduitT ByteString o m Bool
 allBS f = all (BSSeq.oall f)
 
---- Check that at least one value in the stream returns True.
----
---- Subject to shortcut logic: at the first True, consumption of the stream
---- will stop.
+{--
+   Check that at least one value in the stream returns True.
+
+   Subject to shortcut logic: at the first True, consumption of the stream
+   will stop.
+ -}
 any :: Monad m => (a -> Bool) -> ConduitT a o m Bool
 any = fmap isJust . find
 
---- Check that at least one element in the chunked stream returns True.
----
---- Subject to shortcut logic: at the first True, consumption of the stream
---- will stop.
+{--
+   Check that at least one element in the chunked stream returns True.
+
+   Subject to shortcut logic: at the first True, consumption of the stream
+   will stop.
+ -}
 anyE :: (Monad m, Foldable f) => (a -> Bool) -> ConduitT (f a) o m Bool
 anyE f = any (Seq.oany f)
 
---- Check that at least one Char in the String stream returns True.
----
---- Subject to shortcut logic: at the first True, consumption of the stream
---- will stop.
+{--
+   Check that at least one Char in the String stream returns True.
+
+   Subject to shortcut logic: at the first True, consumption of the stream
+   will stop.
+ -}
 anyStr :: Monad m => (Char -> Bool) -> ConduitT String o m Bool
 anyStr f = any (StrSeq.oany f)
 
---- Check that at least one Byte in the ByteString stream returns True.
----
---- Subject to shortcut logic: at the first True, consumption of the stream
---- will stop.
+{--
+   Check that at least one Byte in the ByteString stream returns True.
+
+   Subject to shortcut logic: at the first True, consumption of the stream
+   will stop.
+ -}
 anyBS :: Monad m => (Byte -> Bool) -> ConduitT ByteString o m Bool
 anyBS f = any (BSSeq.oany f)
 
---- Are all values in the stream True?
----
---- Consumption stops once the first False is encountered.
+{--
+   Are all values in the stream True?
+
+   Consumption stops once the first False is encountered.
+ -}
 and :: Monad m => ConduitT Bool o m Bool
 and = all id
 
---- Are all elements in the chunked stream True?
----
---- Consumption stops once the first False is encountered.
+{--
+   Are all elements in the chunked stream True?
+
+   Consumption stops once the first False is encountered.
+ -}
 andE :: (Monad m, Foldable f) => ConduitT (f Bool) o m Bool
 andE = allE id
 
---- Are any values in the stream True?
----
---- Consumption stops once the first True is encountered.
+{--
+   Are any values in the stream True?
+
+   Consumption stops once the first True is encountered.
+ -}
 or :: Monad m => ConduitT Bool o m Bool
 or = any id
 
---- Are any elements in the chunked stream True?
----
---- Consumption stops once the first True is encountered.
+{--
+   Are any elements in the chunked stream True?
+
+   Consumption stops once the first True is encountered.
+ -}
 orE :: (Monad m, Foldable f) => ConduitT (f Bool) o m Bool
 orE = anyE id
 
@@ -460,71 +522,91 @@ orE = anyE id
 asum :: (Monad m, Plus f) => ConduitT (f a) o m (f a)
 asum = foldl (<|>) pzero
 
---- Are any values in the stream equal to the given value?
----
---- Stops consuming as soon as a match is found.
+{--
+   Are any values in the stream equal to the given value?
+
+   Stops consuming as soon as a match is found.
+ -}
 elem :: (Monad m, Eq a) => a -> ConduitT a o m Bool
 elem x = any (== x)
 
---- Are any elements in the chunked stream equal to the given element?
----
---- Stops consuming as soon as a match is found.
+{--
+   Are any elements in the chunked stream equal to the given element?
+
+   Stops consuming as soon as a match is found.
+ -}
 elemE :: (Monad m, Foldable f, Eq a) => a -> ConduitT (f a) o m Bool
 elemE f = any (Seq.oelem f)
 
---- Are any Chars in the String stream equal to the given Char?
----
---- Stops consuming as soon as a match is found.
+{--
+   Are any Chars in the String stream equal to the given Char?
+
+   Stops consuming as soon as a match is found.
+ -}
 elemStr :: Monad m => Char -> ConduitT String o m Bool
 elemStr f = any (StrSeq.oelem f)
 
---- Are any Bytes in the ByteString stream equal to the given Byte?
----
---- Stops consuming as soon as a match is found.
+{--
+   Are any Bytes in the ByteString stream equal to the given Byte?
+
+   Stops consuming as soon as a match is found.
+ -}
 elemBS :: Monad m => Byte -> ConduitT ByteString o m Bool
 elemBS f = any (BSSeq.oelem f)
 
---- Are no values in the stream equal to the given value?
----
---- Stops consuming as soon as a match is found.
+{--
+   Are no values in the stream equal to the given value?
+
+   Stops consuming as soon as a match is found.
+ -}
 notElem :: (Monad m, Eq a) => a -> ConduitT a o m Bool
 notElem x = all (/= x)
 
---- Are no elements in the chunked stream equal to the given element?
----
---- Stops consuming as soon as a match is found.
+{--
+   Are no elements in the chunked stream equal to the given element?
+
+   Stops consuming as soon as a match is found.
+ -}
 notElemE :: (Monad m, Foldable f, Eq a) => a -> ConduitT (f a) o m Bool
 notElemE x = all (Seq.onotElem x)
 
---- Are no Chars in the String stream equal to the given Char?
----
---- Stops consuming as soon as a match is found.
+{--
+   Are no Chars in the String stream equal to the given Char?
+
+   Stops consuming as soon as a match is found.
+ -}
 notElemStr :: Monad m => Char -> ConduitT String o m Bool
 notElemStr x = all (StrSeq.onotElem x)
 
---- Are no Bytes in the ByteString stream equal to the given Byte?
----
---- Stops consuming as soon as a match is found.
+{--
+   Are no Bytes in the ByteString stream equal to the given Byte?
+
+   Stops consuming as soon as a match is found.
+ -}
 notElemBS :: Monad m => Byte -> ConduitT ByteString o m Bool
 notElemBS x = all (BSSeq.onotElem x)
 
---- Consume all values from the stream and return as a list. Note that this
---- will pull all values into memory.
----
---- Try @sinkJList@ if this function causes StackOverflow (unconfirmed).
----
---- Porting note: corresponds to Conduit.List.consume
+{--
+   Consume all values from the stream and return as a list. Note that this
+   will pull all values into memory.
+
+   Try @sinkJList@ if this function causes StackOverflow (unconfirmed).
+
+   Porting note: corresponds to Conduit.List.consume
+ -}
 sinkList :: Monad m => ConduitT a o m [a]
 sinkList =
     loop id
   where
     loop front = await >>= maybe (return $ front []) (\x -> loop $ front . (x:))
 
---- Sink incoming values into @java.util.ArrayList@.
----
---- Note that using this function is more memory efficient than @sinkList@ and
---- then converting to a @java.util.ArrayList@, as it avoids intermediate list
---- constructors.
+{--
+   Sink incoming values into @java.util.ArrayList@.
+
+   Note that using this function is more memory efficient than @sinkList@ and
+   then converting to a @java.util.ArrayList@, as it avoids intermediate list
+   constructors.
+ -}
 sinkArrayList :: ConduitT a o (ST s) (Mutable s (ArrayList a))
 sinkArrayList = go
   where
@@ -538,9 +620,11 @@ sinkArrayList = go
 sinkNull :: Monad m => ConduitT a o m ()
 sinkNull = awaitForever $ \_ -> return ()
 
---- Same as @await@, but discards any leading 'onull' values.
----
---- Also see 'awaitNonNullList'.
+{--
+   Same as @await@, but discards any leading 'onull' values.
+
+   Also see 'awaitNonNullList'.
+ -}
 awaitNonNull :: (Monad m, Foldable f) => ConduitT (f a) o m (Maybe (f a))
 awaitNonNull =
     go
@@ -549,8 +633,10 @@ awaitNonNull =
 
     go' = maybe go (return . Just) . Seq.fromNullable
 
---- The specialization of 'awaitNonNull' to a list in order to workaround javac
---- compilation error (likely a Frege bug).
+{--
+   The specialization of 'awaitNonNull' to a list in order to workaround javac
+   compilation error (likely a Frege bug).
+ -}
 awaitNonNullList :: Monad m => ConduitT [a] o m (Maybe [a])
 awaitNonNullList =
     go
@@ -577,9 +663,11 @@ awaitNonNullBS =
 
     go' = maybe go (return . Just) . BSSeq.fromNullable
 
---- Take a single value from the stream, if available.
----
---- Equivalent to 'await'.
+{--
+   Take a single value from the stream, if available.
+
+   Equivalent to 'await'.
+ -}
 head :: Monad m => ConduitT a o m (Maybe a)
 head = await
 
@@ -733,8 +821,10 @@ lengthIfStr f = foldlStr (\cnt a -> if f a then (cnt + 1) else cnt) 0
 lengthIfBS :: (Monad m, Num len) => (Byte -> Bool) -> ConduitT ByteString o m len
 lengthIfBS f = foldlBS (\cnt a -> if f a then (cnt + 1) else cnt) 0
 
---- A strict left fold on a chunked stream, with no starting value.
---- Returns 'Nothing' when the stream is empty.
+{--
+   A strict left fold on a chunked stream, with no starting value.
+   Returns 'Nothing' when the stream is empty.
+ -}
 private foldl1E :: (Monad m, Foldable f) => (a -> a -> a) -> ConduitT (f a) o m (Maybe a)
 private foldl1E f = foldl (foldMaybeNull f) Nothing
 
@@ -762,16 +852,20 @@ minimum = foldl1 min
 minimumE :: (Monad m, Foldable f, Ord a) => ConduitT (f a) o m (Maybe a)
 minimumE = foldl1E min
 
---- True if there are no values in the stream.
----
---- This function does not modify the stream.
+{--
+   True if there are no values in the stream.
+
+   This function does not modify the stream.
+ -}
 null :: Monad m => ConduitT a o m Bool
 null = (maybe True (\_ -> False)) `fmap` peek
 
---- True if there are no elements in the chunked stream.
----
---- This function may remove empty leading chunks from the stream, but otherwise
---- will not modify it.
+{--
+   True if there are no elements in the chunked stream.
+
+   This function may remove empty leading chunks from the stream, but otherwise
+   will not modify it.
+ -}
 nullE :: (Monad m, Foldable f) => ConduitT (f a) o m Bool
 nullE =
     go
@@ -779,10 +873,12 @@ nullE =
     go = await >>= maybe (return True) go'
     go' x = if Seq.onull x then go else leftover x >> return False
 
---- True if there are no Chars in the String stream.
----
---- This function may remove empty leading chunks from the stream, but otherwise
---- will not modify it.
+{--
+   True if there are no Chars in the String stream.
+
+   This function may remove empty leading chunks from the stream, but otherwise
+   will not modify it.
+ -}
 nullStr :: Monad m => ConduitT String o m Bool
 nullStr =
     go
@@ -790,10 +886,12 @@ nullStr =
     go = await >>= maybe (return True) go'
     go' x = if StrSeq.onull x then go else leftover x >> return False
 
---- True if there are no Bytes in the ByteString stream.
----
---- This function may remove empty leading chunks from the stream, but otherwise
---- will not modify it.
+{--
+   True if there are no Bytes in the ByteString stream.
+
+   This function may remove empty leading chunks from the stream, but otherwise
+   will not modify it.
+ -}
 nullBS :: Monad m => ConduitT ByteString o m Bool
 nullBS =
     go
@@ -825,37 +923,45 @@ find f =
     loop = await >>= maybe (return Nothing) go
     go x = if f x then return (Just x) else loop
 
---- Apply the action to all values in the stream.
----
---- Note: if you want to /pass/ the values instead of /consuming/ them, use
---- 'iterM' instead.
+{--
+   Apply the action to all values in the stream.
+
+   Note: if you want to /pass/ the values instead of /consuming/ them, use
+   'iterM' instead.
+ -}
 mapM_ :: Monad m => (a -> m ()) -> ConduitT a o m ()
 mapM_ f = awaitForever $ lift . f
 
---- Apply the action to all elements in the chunked stream.
----
---- Note: the same caveat as with 'mapM_' applies. If you don't want to
---- consume the values, you can use 'iterM':
----
---- > iterM (omapM_ f)
+{--
+   Apply the action to all elements in the chunked stream.
+
+   Note: the same caveat as with 'mapM_' applies. If you don't want to
+   consume the values, you can use 'iterM':
+
+   > iterM (omapM_ f)
+ -}
 mapM_E :: (Monad m, Foldable f) => (a -> m ()) -> ConduitT (f a) o m ()
 mapM_E f = mapM_ (Seq.omapM_ f)
 
---- Apply the action to all Chars in the String stream.
----
---- Note: the same caveat as with 'mapM_' applies. If you don't want to
---- consume the values, you can use 'iterM':
----
---- > iterM (omapM_ f)
+{--
+   Apply the action to all Chars in the String stream.
+
+   Note: the same caveat as with 'mapM_' applies. If you don't want to
+   consume the values, you can use 'iterM':
+
+   > iterM (omapM_ f)
+ -}
 mapM_Str :: Monad m => (Char -> m ()) -> ConduitT String o m ()
 mapM_Str f = mapM_ (StrSeq.omapM_ f)
 
---- Apply the action to all Bytes in the ByteString stream.
----
---- Note: the same caveat as with 'mapM_' applies. If you don't want to
---- consume the values, you can use 'iterM':
----
---- > iterM (omapM_ f)
+{--
+   Apply the action to all Bytes in the ByteString stream.
+
+   Note: the same caveat as with 'mapM_' applies. If you don't want to
+   consume the values, you can use 'iterM':
+
+   > iterM (omapM_ f)
+ -}
 mapM_BS :: Monad m => (Byte -> m ()) -> ConduitT ByteString o m ()
 mapM_BS f = mapM_ (BSSeq.omapM_ f)
 
@@ -887,18 +993,24 @@ foldMBS f = foldM (BSSeq.ofoldlM f)
 foldMapM :: (Monad m, Monoid w) => (a -> m w) -> ConduitT a o m w
 foldMapM f = let combiner accum = liftM (mappend accum) . f in foldM combiner mempty
 
---- Apply the provided monadic mapping function and monoidal combine all
---- elements in the chunked stream.
+{--
+   Apply the provided monadic mapping function and monoidal combine all
+   elements in the chunked stream.
+ -}
 foldMapME :: (Monad m, Foldable f, Monoid w) => (a -> m w) -> ConduitT (f a) o m w
 foldMapME f = foldM (Seq.ofoldlM (\accum e -> mappend accum `liftM` f e)) mempty
 
---- Apply the provided monadic mapping function and monoidal combine all
---- Chars in the String stream.
+{--
+   Apply the provided monadic mapping function and monoidal combine all
+   Chars in the String stream.
+ -}
 foldMapMStr :: (Monad m, Monoid w) => (Char -> m w) -> ConduitT String o m w
 foldMapMStr f = foldM (StrSeq.ofoldlM (\accum e -> mappend accum `liftM` f e)) mempty
 
---- Apply the provided monadic mapping function and monoidal combine all
---- Bytes in the ByteString stream.
+{--
+   Apply the provided monadic mapping function and monoidal combine all
+   Bytes in the ByteString stream.
+ -}
 foldMapMBS :: (Monad m, Monoid w) => (Byte -> m w) -> ConduitT ByteString o m w
 foldMapMBS f = foldM (BSSeq.ofoldlM (\accum e -> mappend accum `liftM` f e)) mempty
 
@@ -920,13 +1032,13 @@ private data Files = pure native java.nio.file.Files where
     :: Path -> IOMutable FO.OutputStream throws IOException
 
 {--
- - The common implementation of 'sinkTempFile' and 'sinkSystemTempFile'.
- -
- - Splits the pattern string at the last period to insert a random name between
- - them.
- -
- - e.g. With a pattern "foo.bar", a temporary file named
- - "foo-<random string>.bar" is created.
+   The common implementation of 'sinkTempFile' and 'sinkSystemTempFile'.
+
+   Splits the pattern string at the last period to insert a random name between
+   them.
+
+   e.g. With a pattern "foo.bar", a temporary file named
+   "foo-<random string>.bar" is created.
  -}
 private sinkTempFileImpl
   :: MonadResource m
@@ -947,12 +1059,12 @@ private sinkTempFileImpl pattern mktemp = do
     pure p.toString
 
 {--
- - Stream data into a temporary file in the given directory with the
- - given filename pattern, and return the temporary filename. The
- - temporary file will be automatically deleted when exiting the
- - active 'ResourceT' block, if it still exists.
- -
- - Porting note: implemented with @java.nio.file.Files.createTempFile@.
+   Stream data into a temporary file in the given directory with the
+   given filename pattern, and return the temporary filename. The
+   temporary file will be automatically deleted when exiting the
+   active 'ResourceT' block, if it still exists.
+
+   Porting note: implemented with @java.nio.file.Files.createTempFile@.
  -}
 sinkTempFile :: MonadResource m
              => FilePath -- temp directory
@@ -963,10 +1075,10 @@ sinkTempFile tmpdir pattern = sinkTempFileImpl pattern $ \prefix suffix -> do
     Files.createTempFile tmpdirp prefix suffix
 
 {--
- - Same as 'sinkTempFile', but will use the default temp file
- - directory for the system as the first argument.
- -
- - Porting note: implemented with @java.nio.file.Files.createTempFile@.
+   Same as 'sinkTempFile', but will use the default temp file
+   directory for the system as the first argument.
+
+   Porting note: implemented with @java.nio.file.Files.createTempFile@.
  -}
 sinkSystemTempFile
     :: MonadResource m
@@ -974,17 +1086,21 @@ sinkSystemTempFile
     -> ConduitT ByteString o m FilePath
 sinkSystemTempFile pattern = sinkTempFileImpl pattern Files.createTempFile
 
---- Stream all incoming data to the given 'OutputStream'. Note that this function
---- does /not/ flush and will /not/ close the @Handle@ when processing completes.
+{--
+   Stream all incoming data to the given 'OutputStream'. Note that this function
+   does /not/ flush and will /not/ close the @Handle@ when processing completes.
+ -}
 sinkOutputStream :: MonadIO m
                  => MutableIO FO.OutputStream
                  -> ConduitT ByteString o m ()
 sinkOutputStream os = awaitForever (liftIO . FO.writeBS os)
 
---- An alternative to 'sinkOutputStream'.
---- Instead of taking a pre-opened 'OutputStream', it takes an action that
---- opens an 'OutputStream', so that it can open it only when needed and close
---- it as soon as possible.
+{--
+   An alternative to 'sinkOutputStream'.
+   Instead of taking a pre-opened 'OutputStream', it takes an action that
+   opens an 'OutputStream', so that it can open it only when needed and close
+   it as soon as possible.
+ -}
 sinkIOOutputStream :: MonadResource m
                    => IOMutable FO.OutputStream
                    -> ConduitT ByteString o m ()
@@ -1002,8 +1118,10 @@ stdout = sinkOutputStream systemOut
 stderr :: MonadIO m => ConduitT ByteString o m ()
 stderr = sinkOutputStream systemErr
 
---- Like 'IO.withBinaryFile' in Haskell, but provides a sink to write bytes
---- to.
+{--
+   Like 'IO.withBinaryFile' in Haskell, but provides a sink to write bytes
+   to.
+ -}
 withSinkFile
   :: (MonadUnliftIO m, MonadIO n)
   => FilePath
@@ -1022,83 +1140,103 @@ map f = awaitForever $ yield . f
 mapE :: (Monad m, Functor f) => (a -> b) -> ConduitT (f a) (f b) m ()
 mapE = map . fmap
 
---- Apply a monomorphic transformation to all elements in a chunked stream.
----
---- Unlike @mapE@, this will work on types like @ByteString@ and @Text@ which
---- are @MonoFunctor@ but not @Functor@.
----
---- Porting note: in absence of @MonoFunctor@, this function makes no sense,
---- but provided anyway for future compatibility.
+{--
+   Apply a monomorphic transformation to all elements in a chunked stream.
+
+   Unlike @mapE@, this will work on types like @ByteString@ and @Text@ which
+   are @MonoFunctor@ but not @Functor@.
+
+   Porting note: in absence of @MonoFunctor@, this function makes no sense,
+   but provided anyway for future compatibility.
+ -}
 omapE :: (Monad m, Functor f) => (a -> a) -> ConduitT (f a) (f a) m ()
 omapE = map . Seq.omap
 
---- Apply a monomorphic transformation to all Chars in a String stream.
----
---- Unlike @mapE@, this will work on types like @String@ which is
---- @MonoFunctor@ but not @Functor@.
+{--
+   Apply a monomorphic transformation to all Chars in a String stream.
+
+   Unlike @mapE@, this will work on types like @String@ which is
+   @MonoFunctor@ but not @Functor@.
+ -}
 omapStr :: Monad m => (Char -> Char) -> ConduitT String String m ()
 omapStr = map . StrSeq.omap
 
---- Apply a monomorphic transformation to all Bytes in a String stream.
----
---- Unlike @mapE@, this will work on types like @ByteString@ which is
---- @MonoFunctor@ but not @Functor@.
+{--
+   Apply a monomorphic transformation to all Bytes in a String stream.
+
+   Unlike @mapE@, this will work on types like @ByteString@ which is
+   @MonoFunctor@ but not @Functor@.
+ -}
 omapBS :: Monad m => (Byte -> Byte) -> ConduitT ByteString ByteString m ()
 omapBS = map . BSSeq.omap
 
---- Apply the function to each value in the stream, resulting in a foldable
---- value (e.g., a list). Then yield each of the individual values in that
---- foldable value separately.
----
---- Generalizes concatMap, mapMaybe, and mapFoldable.
+{--
+   Apply the function to each value in the stream, resulting in a foldable
+   value (e.g., a list). Then yield each of the individual values in that
+   foldable value separately.
+
+   Generalizes concatMap, mapMaybe, and mapFoldable.
+ -}
 concatMap :: (Monad m, Foldable f) => (a -> f b) -> ConduitT a b m ()
 concatMap f = awaitForever (yieldMany . f)
 
---- Apply the function to each value in the stream, resulting in a String.
---- Then yield each of the individual Chars in that String separately.
----
---- Generalizes concatMap, mapMaybe, and mapFoldable.
+{--
+   Apply the function to each value in the stream, resulting in a String.
+   Then yield each of the individual Chars in that String separately.
+
+   Generalizes concatMap, mapMaybe, and mapFoldable.
+ -}
 concatMapStr :: Monad m => (a -> String) -> ConduitT a Char m ()
 concatMapStr f = awaitForever (yieldManyStr . f)
 
---- Apply the function to each value in the stream, resulting in a ByteString.
---- Then yield each of the individual Bytes in that String separately.
----
---- Generalizes concatMap, mapMaybe, and mapFoldable.
+{--
+   Apply the function to each value in the stream, resulting in a ByteString.
+   Then yield each of the individual Bytes in that String separately.
+
+   Generalizes concatMap, mapMaybe, and mapFoldable.
+ -}
 concatMapBS :: Monad m => (a -> ByteString) -> ConduitT a Byte m ()
 concatMapBS f = awaitForever (yieldManyBS . f)
 
---- Apply the function to each element in the chunked stream, resulting in a
---- foldable value (e.g., a list). Then yield each of the individual values in
---- that foldable value separately.
----
---- Generalizes concatMap, mapMaybe, and mapFoldable.
+{--
+   Apply the function to each element in the chunked stream, resulting in a
+   foldable value (e.g., a list). Then yield each of the individual values in
+   that foldable value separately.
+
+   Generalizes concatMap, mapMaybe, and mapFoldable.
+ -}
 concatMapE :: (Monad m, Foldable f, Monoid w) => (a -> w) -> ConduitT (f a) w m ()
 concatMapE f = map (Seq.ofoldMap f)
 
---- Apply the function to each Char in the String stream, resulting in a
---- foldable value (e.g., a list). Then yield each of the individual values
---- in that foldable value separately.
----
---- Generalizes concatMap, mapMaybe, and mapFoldable.
+{--
+   Apply the function to each Char in the String stream, resulting in a
+   foldable value (e.g., a list). Then yield each of the individual values
+   in that foldable value separately.
+
+   Generalizes concatMap, mapMaybe, and mapFoldable.
+ -}
 concatMapEStr :: (Monad m, Monoid w) => (Char -> w) -> ConduitT String w m ()
 concatMapEStr f = map (StrSeq.ofoldMap f)
 
---- Apply the function to each Byte in the ByteString stream, resulting in a
---- foldable value (e.g., a list). Then yield each of the individual values
---- in that foldable value separately.
----
---- Generalizes concatMap, mapMaybe, and mapFoldable.
+{--
+   Apply the function to each Byte in the ByteString stream, resulting in a
+   foldable value (e.g., a list). Then yield each of the individual values
+   in that foldable value separately.
+
+   Generalizes concatMap, mapMaybe, and mapFoldable.
+ -}
 concatMapEBS :: (Monad m, Monoid w) => (Byte -> w) -> ConduitT ByteString w m ()
 concatMapEBS f = map (BSSeq.ofoldMap f)
 
---- Stream up to n number of values downstream.
----
---- Note that, if downstream terminates early, not all values will be consumed.
---- If you want to force /exactly/ the given number of values to be consumed,
---- see 'takeExactly'.
----
---- Porting note: corresponds to Conduit.List.isolate
+{--
+   Stream up to n number of values downstream.
+
+   Note that, if downstream terminates early, not all values will be consumed.
+   If you want to force /exactly/ the given number of values to be consumed,
+   see 'takeExactly'.
+
+   Porting note: corresponds to Conduit.List.isolate
+ -}
 take :: Monad m => Int -> ConduitT a a m ()
 take =
     loop
@@ -1106,11 +1244,13 @@ take =
     loop count | count <= 0 = return ()
     loop count = await >>= maybe (return ()) (\x -> yield x >> loop (count - 1))
 
---- Stream up to n number of elements downstream in a chunked stream.
----
---- Note that, if downstream terminates early, not all values will be consumed.
---- If you want to force /exactly/ the given number of values to be consumed,
---- see 'takeExactlyE'.
+{--
+   Stream up to n number of elements downstream in a chunked stream.
+
+   Note that, if downstream terminates early, not all values will be consumed.
+   If you want to force /exactly/ the given number of values to be consumed,
+   see 'takeExactlyE'.
+ -}
 takeE :: (Monad m, Foldable f, ListView f) => Int -> ConduitT (f a) (f a) m ()
 takeE =
     loop
@@ -1127,11 +1267,13 @@ takeE =
         (x, y) = Seq.splitAt i sq
         i' = i - fromIntegral (Seq.olength x)
 
---- Stream up to n number of Chars downstream in a String stream.
----
---- Note that, if downstream terminates early, not all values will be consumed.
---- If you want to force /exactly/ the given number of values to be consumed,
---- see 'takeExactlyStr'.
+{--
+   Stream up to n number of Chars downstream in a String stream.
+
+   Note that, if downstream terminates early, not all values will be consumed.
+   If you want to force /exactly/ the given number of values to be consumed,
+   see 'takeExactlyStr'.
+ -}
 takeStr :: Monad m => Int -> ConduitT String String m ()
 takeStr =
     loop
@@ -1148,11 +1290,13 @@ takeStr =
         (x, y) = StrSeq.splitAt i sq
         i' = i - fromIntegral (StrSeq.olength x)
 
---- Stream up to n number of Bytes downstream in a ByteString stream.
----
---- Note that, if downstream terminates early, not all values will be consumed.
---- If you want to force /exactly/ the given number of values to be consumed,
---- see 'takeExactlyStr'.
+{--
+   Stream up to n number of Bytes downstream in a ByteString stream.
+
+   Note that, if downstream terminates early, not all values will be consumed.
+   If you want to force /exactly/ the given number of values to be consumed,
+   see 'takeExactlyStr'.
+ -}
 takeBS :: Monad m => Int -> ConduitT ByteString ByteString m ()
 takeBS =
     loop
@@ -1169,9 +1313,11 @@ takeBS =
         (x, y) = BSSeq.splitAt i sq
         i' = i - fromIntegral (BSSeq.olength x)
 
---- Stream all values downstream that match the given predicate. (sic)
----
---- Same caveats regarding downstream termination apply as with 'take'.
+{--
+   Stream all values downstream that match the given predicate. (sic)
+
+   Same caveats regarding downstream termination apply as with 'take'.
+ -}
 takeWhile :: Monad m => (a -> Bool) -> ConduitT a a m ()
 takeWhile f =
     loop
@@ -1181,9 +1327,11 @@ takeWhile f =
         then yield x >> loop
         else leftover x
 
---- Stream all elements downstream that match the given predicate in a chunked stream.
----
---- Same caveats regarding downstream termination apply as with 'takeE'.
+{--
+   Stream all elements downstream that match the given predicate in a chunked stream.
+
+   Same caveats regarding downstream termination apply as with 'takeE'.
+ -}
 takeWhileE :: (Monad m) => (a -> Bool) -> ConduitT [a] [a] m ()
 takeWhileE f =
     loop
@@ -1198,9 +1346,11 @@ takeWhileE f =
       where
         (x, y) = Seq.span f sq
 
---- Stream all Chars downstream that match the given predicate in a String stream.
----
---- Same caveats regarding downstream termination apply as with 'takeStr'.
+{--
+   Stream all Chars downstream that match the given predicate in a String stream.
+
+   Same caveats regarding downstream termination apply as with 'takeStr'.
+ -}
 takeWhileStr :: Monad m => (Char -> Bool) -> ConduitT String String m ()
 takeWhileStr f =
     loop
@@ -1215,9 +1365,11 @@ takeWhileStr f =
       where
         (x, y) = StrSeq.span f sq
 
---- Stream all Bytes downstream that match the given predicate in a ByteString stream.
----
---- Same caveats regarding downstream termination apply as with 'takeStr'.
+{--
+   Stream all Bytes downstream that match the given predicate in a ByteString stream.
+
+   Same caveats regarding downstream termination apply as with 'takeStr'.
+ -}
 takeWhileBS :: Monad m => (Byte -> Bool) -> ConduitT ByteString ByteString m ()
 takeWhileBS f =
     loop
@@ -1232,17 +1384,19 @@ takeWhileBS f =
       where
         (x, y) = BSSeq.span f sq
 
---- Consume precisely the given number of values and feed them downstream.
----
---- This function is in contrast to 'take', which will only consume up to the
---- given number of values, and will terminate early if downstream terminates
---- early. This function will discard any additional values in the stream if
---- they are unconsumed.
----
---- Note that this function takes a downstream @ConduitT@ as a parameter, as
---- opposed to working with normal fusion. For more information, see
---- <http://www.yesodweb.com/blog/2013/10/core-flaw-pipes-conduit>, the section
---- titled \"pipes and conduit: isolate\".
+{--
+   Consume precisely the given number of values and feed them downstream.
+
+   This function is in contrast to 'take', which will only consume up to the
+   given number of values, and will terminate early if downstream terminates
+   early. This function will discard any additional values in the stream if
+   they are unconsumed.
+
+   Note that this function takes a downstream @ConduitT@ as a parameter, as
+   opposed to working with normal fusion. For more information, see
+   <http://www.yesodweb.com/blog/2013/10/core-flaw-pipes-conduit>, the section
+   titled \"pipes and conduit: isolate\".
+ -}
 takeExactly :: Monad m => Int -> ConduitT a b m r -> ConduitT a b m r
 takeExactly count inner = take count .| do
     r <- inner
@@ -1270,25 +1424,33 @@ takeExactlyBS count inner = takeBS count .| do
     sinkNull
     return r
 
---- Flatten out a stream by yielding the values contained in an incoming
---- @Foldable@ as individually yielded values.
----
---- Also see 'concatList'.
+{--
+   Flatten out a stream by yielding the values contained in an incoming
+   @Foldable@ as individually yielded values.
+
+   Also see 'concatList'.
+ -}
 concat :: (Monad m, Foldable f) => ConduitT (f a) a m ()
 concat = awaitForever yieldMany
 
---- The specialization of 'concat' to a list in order to workaround javac
---- compilation error (likely a Frege bug).
+{--
+   The specialization of 'concat' to a list in order to workaround javac
+   compilation error (likely a Frege bug).
+ -}
 concatList :: Monad m => ConduitT [a] a m ()
 concatList = awaitForever yieldMany
 
---- Flatten out a String stream by yielding the Chars contained in an incoming
---- @String@ as individually yielded values.
+{--
+   Flatten out a String stream by yielding the Chars contained in an incoming
+   @String@ as individually yielded values.
+ -}
 concatStr :: Monad m => ConduitT String Char m ()
 concatStr = awaitForever yieldManyStr
 
---- Flatten out a String stream by yielding the Bytes contained in an incoming
---- @ByteString@ as individually yielded values.
+{--
+   Flatten out a String stream by yielding the Bytes contained in an incoming
+   @ByteString@ as individually yielded values.
+ -}
 concatBS :: Monad m => ConduitT ByteString Byte m ()
 concatBS = awaitForever yieldManyBS
 
@@ -1332,10 +1494,12 @@ scanl f =
             yield seed
             loop seed'
 
---- 'mapWhile' with a break condition dependent on a strict accumulator.
---- Equivalently, 'mapAccum' as long as the result is @Right@. Instead of
---- producing a leftover, the breaking input determines the resulting
---- accumulator via @Left@.
+{--
+   'mapWhile' with a break condition dependent on a strict accumulator.
+   Equivalently, 'mapAccum' as long as the result is @Right@. Instead of
+   producing a leftover, the breaking input determines the resulting
+   accumulator via @Left@.
+ -}
 mapAccumWhile :: Monad m => (a -> s -> Either s (s, b)) -> s -> ConduitT a b m s
 mapAccumWhile f =
     loop
@@ -1344,11 +1508,13 @@ mapAccumWhile f =
       where
         go a = either (return $!) (\(s', b) -> yield b >> loop s') $ f a s
 
---- Analog of @mapAccumL@ for lists. Note that in contrast to @mapAccumL@, the function argument
---- takes the accumulator as its second argument, not its first argument, and the accumulated value
---- is strict.
----
---- Porting note: ported from Data.Conduit.List
+{--
+   Analog of @mapAccumL@ for lists. Note that in contrast to @mapAccumL@, the function argument
+   takes the accumulator as its second argument, not its first argument, and the accumulated value
+   is strict.
+
+   Porting note: ported from Data.Conduit.List
+ -}
 mapAccum :: Monad m => (a -> s -> (s, b)) -> s -> ConduitT a b m s
 mapAccum f =
     loop
@@ -1369,11 +1535,13 @@ intersperse x =
   where
     go y = yield y >> concatMap (\z -> [x, z])
 
---- Sliding window of values
---- 1,2,3,4,5 with window size 2 gives
---- [1,2],[2,3],[3,4],[4,5]
----
---- Best used with structures that support O(1) snoc.
+{--
+   Sliding window of values
+   1,2,3,4,5 with window size 2 gives
+   [1,2],[2,3],[3,4],[4,5]
+
+   Best used with structures that support O(1) snoc.
+ -}
 slidingWindow :: Monad m => Int -> ConduitT a [a] m ()
 slidingWindow sz = go (max 1 sz) mempty
     where goContinue st = await >>=
@@ -1388,31 +1556,39 @@ slidingWindow sz = go (max 1 sz) mempty
                        Nothing -> yield st
                        Just x -> go (n-1) (Seq.snoc st x)
 
---- Split input into chunk of size 'chunkSize'
----
---- The last element may be smaller than the 'chunkSize' (see also
---- 'chunksOfExactlyE' which will not yield this last element)
+{--
+   Split input into chunk of size 'chunkSize'
+
+   The last element may be smaller than the 'chunkSize' (see also
+   'chunksOfExactlyE' which will not yield this last element)
+ -}
 chunksOfE :: (Monad m, Foldable f, ListView f, Monoid (f a)) => Int -> ConduitT (f a) (f a) m ()
 chunksOfE chunkSize = chunksOfExactlyE chunkSize >> (await >>= maybe (return ()) yield)
 
---- Split input into chunk of size 'chunkSize'
----
---- The last element may be smaller than the 'chunkSize' (see also
---- 'chunksOfExactlyStr' which will not yield this last element)
+{--
+   Split input into chunk of size 'chunkSize'
+
+   The last element may be smaller than the 'chunkSize' (see also
+   'chunksOfExactlyStr' which will not yield this last element)
+ -}
 chunksOfStr :: (Monad m) => Int -> ConduitT String String m ()
 chunksOfStr chunkSize = chunksOfExactlyStr chunkSize >> (await >>= maybe (return ()) yield)
 
---- Split input into chunk of size 'chunkSize'
----
---- The last element may be smaller than the 'chunkSize' (see also
---- 'chunksOfExactlyBS' which will not yield this last element)
+{--
+   Split input into chunk of size 'chunkSize'
+
+   The last element may be smaller than the 'chunkSize' (see also
+   'chunksOfExactlyBS' which will not yield this last element)
+ -}
 chunksOfBS :: (Monad m) => Int -> ConduitT ByteString ByteString m ()
 chunksOfBS chunkSize = chunksOfExactlyBS chunkSize >> (await >>= maybe (return ()) yield)
 
---- Split input into chunk of size 'chunkSize'
----
---- If the input does not split into chunks exactly, the remainder will be
---- leftover (see also 'chunksOfE')
+{--
+   Split input into chunk of size 'chunkSize'
+
+   If the input does not split into chunks exactly, the remainder will be
+   leftover (see also 'chunksOfE')
+ -}
 chunksOfExactlyE :: (Monad m, Foldable f, ListView f, Monoid (f a)) => Int -> ConduitT (f a) (f a) m ()
 chunksOfExactlyE chunkSize = await >>= maybe (return ()) start
     where
@@ -1432,10 +1608,12 @@ chunksOfExactlyE chunkSize = await >>= maybe (return ()) start
                             then continue sofar' bs'
                             else start (mconcat (Prelude.reverse bs'))
 
---- Split input into chunk of size 'chunkSize'
----
---- If the input does not split into chunks exactly, the remainder will be
---- leftover (see also 'chunksOfStr')
+{--
+   Split input into chunk of size 'chunkSize'
+
+   If the input does not split into chunks exactly, the remainder will be
+   leftover (see also 'chunksOfStr')
+ -}
 chunksOfExactlyStr :: (Monad m) => Int -> ConduitT String String m ()
 chunksOfExactlyStr chunkSize = await >>= maybe (return ()) start
     where
@@ -1455,10 +1633,12 @@ chunksOfExactlyStr chunkSize = await >>= maybe (return ()) start
                             then continue sofar' bs'
                             else start (mconcat (Prelude.reverse bs'))
 
---- Split input into chunk of size 'chunkSize'
----
---- If the input does not split into chunks exactly, the remainder will be
---- leftover (see also 'chunksOfBS')
+{--
+   Split input into chunk of size 'chunkSize'
+
+   If the input does not split into chunks exactly, the remainder will be
+   leftover (see also 'chunksOfBS')
+ -}
 chunksOfExactlyBS :: (Monad m) => Int -> ConduitT ByteString ByteString m ()
 chunksOfExactlyBS chunkSize = await >>= maybe (return ()) start
     where
@@ -1478,10 +1658,12 @@ chunksOfExactlyBS chunkSize = await >>= maybe (return ()) start
                             then continue sofar' bs'
                             else start (mconcat (Prelude.reverse bs'))
 
---- Apply a monadic transformation to all values in a stream.
----
---- If you do not need the transformed values, and instead just want the monadic
---- side-effects of running the action, see 'mapM_'.
+{--
+   Apply a monadic transformation to all values in a stream.
+
+   If you do not need the transformed values, and instead just want the monadic
+   side-effects of running the action, see 'mapM_'.
+ -}
 mapM :: Monad m => (a -> m b) -> ConduitT a b m ()
 mapM f = awaitForever $ \a -> lift (f a) >>= yield
 
@@ -1489,49 +1671,61 @@ mapM f = awaitForever $ \a -> lift (f a) >>= yield
 mapME :: (Monad m, Traversable f) => (a -> m b) -> ConduitT (f a) (f b) m ()
 mapME f = mapM (Traversable.mapM f)
 
---- Apply a monadic monomorphic transformation to all elements in a chunked stream.
----
---- Unlike @mapME@, this will work on types like @ByteString@ and @Text@ which
---- are @MonoFunctor@ but not @Functor@.
----
---- Porting note: in absence of @MonoFunctor@, this function makes no sense,
---- but provided anyway for future compatibility.
+{--
+   Apply a monadic monomorphic transformation to all elements in a chunked stream.
+
+   Unlike @mapME@, this will work on types like @ByteString@ and @Text@ which
+   are @MonoFunctor@ but not @Functor@.
+
+   Porting note: in absence of @MonoFunctor@, this function makes no sense,
+   but provided anyway for future compatibility.
+ -}
 omapME :: (Monad m, Traversable f) => (a -> m a) -> ConduitT (f a) (f a) m ()
 omapME f = mapM (Seq.omapM f)
 
---- Apply a monadic monomorphic transformation to all Chars in a String stream.
----
---- Unlike @mapME@, this will work on types like @String@ which is
---- @MonoFunctor@ but not @Functor@.
+{--
+   Apply a monadic monomorphic transformation to all Chars in a String stream.
+
+   Unlike @mapME@, this will work on types like @String@ which is
+   @MonoFunctor@ but not @Functor@.
+ -}
 omapMStr :: Monad m => (Char -> m Char) -> ConduitT String String m ()
 omapMStr f = mapM (StrSeq.omapM f)
 
---- Apply a monadic monomorphic transformation to all Bytes in a ByteString stream.
----
---- Unlike @mapME@, this will work on types like @ByteString@ which is
---- @MonoFunctor@ but not @Functor@.
+{--
+   Apply a monadic monomorphic transformation to all Bytes in a ByteString stream.
+
+   Unlike @mapME@, this will work on types like @ByteString@ which is
+   @MonoFunctor@ but not @Functor@.
+ -}
 omapMBS :: Monad m => (Byte -> m Byte) -> ConduitT ByteString ByteString m ()
 omapMBS f = mapM (BSSeq.omapM f)
 
---- Apply the monadic function to each value in the stream, resulting in a
---- foldable value (e.g., a list). Then yield each of the individual values in
---- that foldable value separately.
----
---- Generalizes concatMapM, mapMaybeM, and mapFoldableM.
+{--
+   Apply the monadic function to each value in the stream, resulting in a
+   foldable value (e.g., a list). Then yield each of the individual values in
+   that foldable value separately.
+
+   Generalizes concatMapM, mapMaybeM, and mapFoldableM.
+ -}
 concatMapM :: (Monad m, Foldable f) => (a -> m (f b)) -> ConduitT a b m ()
 concatMapM f = awaitForever (lift . f >=> yieldMany)
 
---- Apply the monadic function to each value in the stream, resulting in a
---- String. Then yield each of the individual Chars in that String separately.
----
---- Generalizes concatMapM, mapMaybeM, and mapFoldableM.
+{--
+   Apply the monadic function to each value in the stream, resulting in a
+   String. Then yield each of the individual Chars in that String separately.
+
+   Generalizes concatMapM, mapMaybeM, and mapFoldableM.
+ -}
 concatMapMStr :: Monad m => (a -> m String) -> ConduitT a Char m ()
 concatMapMStr f = awaitForever (lift . f >=> yieldManyStr)
 
---- Apply the monadic function to each value in the stream, resulting in a
---- ByteString. Then yield each of the individual Bytes in that ByteString separately.
----
---- Generalizes concatMapM, mapMaybeM, and mapFoldableM.
+{--
+   Apply the monadic function to each value in the stream, resulting in a
+   ByteString. Then yield each of the individual Bytes in that ByteString separately.
+
+   Generalizes concatMapM, mapMaybeM, and mapFoldableM.
+ -}
 concatMapMBS :: Monad m => (a -> m ByteString) -> ConduitT a Byte m ()
 concatMapMBS f = awaitForever (lift . f >=> yieldManyBS)
 
@@ -1556,12 +1750,14 @@ filterMStr f = mapM (StrSeq.filterM f)
 filterMBS :: Monad m => (Byte -> m Bool) -> ConduitT ByteString ByteString m ()
 filterMBS f = mapM (BSSeq.filterM f)
 
---- Apply a monadic action on all values in a stream.
----
---- This @Conduit@ can be used to perform a monadic side-effect for every
---- value, whilst passing the value through the @Conduit@ as-is.
----
---- > iterM f = mapM (\a -> f a >>= \() -> return a)
+{--
+   Apply a monadic action on all values in a stream.
+
+   This @Conduit@ can be used to perform a monadic side-effect for every
+   value, whilst passing the value through the @Conduit@ as-is.
+
+   > iterM f = mapM (\a -> f a >>= \() -> return a)
+ -}
 iterM :: Monad m => (a -> m ()) -> ConduitT a a m ()
 iterM f = awaitForever $ \a -> lift (f a) >> yield a
 
@@ -1587,9 +1783,11 @@ mapAccumWhileM f =
       where
         go a = lift (f a s) >>= either (return $!) (\(s', b) -> yield b >> loop s')
 
---- Monadic `mapAccum`.
----
---- Porting note: ported from Data.Conduit.List
+{--
+   Monadic `mapAccum`.
+
+   Porting note: ported from Data.Conduit.List
+ -}
 mapAccumM :: Monad m => (a -> s -> m (s, b)) -> s -> ConduitT a b m s
 mapAccumM f =
     loop
@@ -1608,22 +1806,28 @@ concatMapAccumM f x0 = void (mapAccumM f x0) .| concatList
 encodeUtf8 :: Monad m => ConduitT String ByteString m ()
 encodeUtf8 = map SC.encodeUtf8
 
---- Decode a stream of binary data as UTF8.
----
---- Porting note: does *not* throw an exception; currently, equivalent to
---- 'decodeUtf8Lenient'.
+{--
+   Decode a stream of binary data as UTF8.
+
+   Porting note: does *not* throw an exception; currently, equivalent to
+   'decodeUtf8Lenient'.
+ -}
 decodeUtf8 :: Monad m => ConduitT ByteString String m ()
 decodeUtf8 = decodeUtf8Lenient
 
---- Decode a stream of binary data as UTF8, replacing any invalid bytes with
---- the Unicode replacement character.
+{--
+   Decode a stream of binary data as UTF8, replacing any invalid bytes with
+   the Unicode replacement character.
+ -}
 decodeUtf8Lenient :: Monad m => ConduitT ByteString String m ()
 decodeUtf8Lenient = SC.decodeUtf8Streaming
 
---- Stream in the entirety of a single line.
----
---- Like @takeExactly@, this will consume the entirety of the line regardless of
---- the behavior of the inner Conduit.
+{--
+   Stream in the entirety of a single line.
+
+   Like @takeExactly@, this will consume the entirety of the line regardless of
+   the behavior of the inner Conduit.
+ -}
 line :: Monad m => ConduitT String o m r -> ConduitT String o m r
 line = takeExactlyUntilStr (== '\n')
 
@@ -1640,12 +1844,12 @@ unlinesAscii :: Monad m => ConduitT ByteString ByteString m ()
 unlinesAscii = concatMap (:[S.singleton 10])
 
 {--
- - Split a stream of arbitrarily-chunked String, based on a predicate
- - on Chars.  Chars that satisfy the predicate will cause chunks
- - to be split, and aren't included in these output chunks.  Note
- - that, if you have unknown or untrusted input, this function is
- - /unsafe/, since it would allow an attacker to form chunks of
- - massive length and exhaust memory.
+   Split a stream of arbitrarily-chunked String, based on a predicate
+   on Chars.  Chars that satisfy the predicate will cause chunks
+   to be split, and aren't included in these output chunks.  Note
+   that, if you have unknown or untrusted input, this function is
+   /unsafe/, since it would allow an attacker to form chunks of
+   massive length and exhaust memory.
  -}
 splitOnUnboundedStr :: Monad m => (Char -> Bool) -> ConduitT String String m ()
 splitOnUnboundedStr f =
@@ -1666,7 +1870,7 @@ splitOnUnboundedStr f =
         (x, y) = StrSeq.break f t
 
 {--
- - Same as 'splitOnUnboundedStr', but for @ByteString@.
+   Same as 'splitOnUnboundedStr', but for @ByteString@.
  -}
 splitOnUnboundedBS :: Monad m => (Byte -> Bool) -> ConduitT ByteString ByteString m ()
 splitOnUnboundedBS f =
@@ -1687,30 +1891,32 @@ splitOnUnboundedBS f =
         (x, y) = BSSeq.break f t
 
 {--
- - Convert a stream of arbitrarily-chunked textual data into a stream of data
- - where each chunk represents a single line. Note that, if you have
- - unknown or untrusted input, this function is /unsafe/, since it would allow an
- - attacker to form lines of massive length and exhaust memory.
- -
- - Porting note: chunk type specialized to @String@, whereas the original takes
- - any sequence whose element is @Char@.
+   Convert a stream of arbitrarily-chunked textual data into a stream of data
+   where each chunk represents a single line. Note that, if you have
+   unknown or untrusted input, this function is /unsafe/, since it would allow an
+   attacker to form lines of massive length and exhaust memory.
+
+   Porting note: chunk type specialized to @String@, whereas the original takes
+   any sequence whose element is @Char@.
  -}
 linesUnbounded :: Monad m => ConduitT String String m ()
 linesUnbounded = splitOnUnboundedStr (== '\n')
 
 {--
- - Same as 'linesUnbounded', bot for ASCII/binary data.
- -
- - Porting note: chunk type specialized to @ByteString@, whereas the original takes
- - any sequence whose element is @Word8@.
+   Same as 'linesUnbounded', bot for ASCII/binary data.
+
+   Porting note: chunk type specialized to @ByteString@, whereas the original takes
+   any sequence whose element is @Word8@.
  -}
 linesUnboundedAscii :: Monad m => ConduitT ByteString ByteString m ()
 linesUnboundedAscii = splitOnUnboundedBS (== 10)
 
---- Stream in the chunked input until an element matches a predicate.
----
---- Like @takeExactly@, this will consume the entirety of the prefix
---- regardless of the behavior of the inner Conduit.
+{--
+   Stream in the chunked input until an element matches a predicate.
+
+   Like @takeExactly@, this will consume the entirety of the prefix
+   regardless of the behavior of the inner Conduit.
+ -}
 takeExactlyUntilE :: Monad m
                   => (a -> Bool)
                   -> ConduitT [a] o m r
@@ -1732,10 +1938,12 @@ takeExactlyUntilE f inner =
       where
         (x, y) = Seq.break f t
 
---- Stream in the String input until a Char matches a predicate.
----
---- Like @takeExactly@, this will consume the entirety of the prefix
---- regardless of the behavior of the inner Conduit.
+{--
+   Stream in the String input until a Char matches a predicate.
+
+   Like @takeExactly@, this will consume the entirety of the prefix
+   regardless of the behavior of the inner Conduit.
+ -}
 takeExactlyUntilStr :: Monad m
                     => (Char -> Bool)
                     -> ConduitT String o m r
@@ -1757,10 +1965,12 @@ takeExactlyUntilStr f inner =
       where
         (x, y) = StrSeq.break f t
 
---- Stream in the ByteString input until a Byte matches a predicate.
----
---- Like @takeExactly@, this will consume the entirety of the prefix
---- regardless of the behavior of the inner Conduit.
+{--
+   Stream in the ByteString input until a Byte matches a predicate.
+
+   Like @takeExactly@, this will consume the entirety of the prefix
+   regardless of the behavior of the inner Conduit.
+ -}
 takeExactlyUntilBS :: Monad m
                     => (Byte -> Bool)
                     -> ConduitT ByteString o m r
@@ -1782,8 +1992,10 @@ takeExactlyUntilBS f inner =
       where
         (x, y) = BSSeq.break f t
 
---- Run a consuming conduit repeatedly, only stopping when there is no more
---- data available from upstream.
+{--
+   Run a consuming conduit repeatedly, only stopping when there is no more
+   data available from upstream.
+ -}
 peekForever :: Monad m => ConduitT i o m () -> ConduitT i o m ()
 peekForever inner =
     loop
@@ -1794,13 +2006,15 @@ peekForever inner =
             Nothing -> return ()
             Just _ -> inner >> loop
 
---- Run a consuming conduit repeatedly, only stopping when there is no more
---- data available from upstream.
----
---- In constrast to 'peekForever', this function will ignore empty
---- chunks of data. So for example, if a stream of data contains an
---- empty @ByteString@, it is still treated as empty, and the consuming
---- function is not called.
+{--
+   Run a consuming conduit repeatedly, only stopping when there is no more
+   data available from upstream.
+
+   In constrast to 'peekForever', this function will ignore empty
+   chunks of data. So for example, if a stream of data contains an
+   empty @ByteString@, it is still treated as empty, and the consuming
+   function is not called.
+ -}
 peekForeverE :: (Monad m, ListView f) => ConduitT (f a) o m () -> ConduitT (f a) o m ()
 peekForeverE inner =
     loop
@@ -1811,13 +2025,15 @@ peekForeverE inner =
             Nothing -> return ()
             Just _ -> inner >> loop
 
---- Run a consuming conduit repeatedly, only stopping when there is no more
---- data available from upstream.
----
---- In constrast to 'peekForever', this function will ignore empty
---- Strings. So for example, if a stream of data contains an
---- empty @String@, it is still treated as empty, and the consuming
---- function is not called.
+{--
+   Run a consuming conduit repeatedly, only stopping when there is no more
+   data available from upstream.
+
+   In constrast to 'peekForever', this function will ignore empty
+   Strings. So for example, if a stream of data contains an
+   empty @String@, it is still treated as empty, and the consuming
+   function is not called.
+ -}
 peekForeverStr :: Monad m => ConduitT String o m () -> ConduitT String o m ()
 peekForeverStr inner =
     loop
@@ -1828,13 +2044,15 @@ peekForeverStr inner =
             Nothing -> return ()
             Just _ -> inner >> loop
 
---- Run a consuming conduit repeatedly, only stopping when there is no more
---- data available from upstream.
----
---- In constrast to 'peekForever', this function will ignore empty
---- ByteStrings. So for example, if a stream of data contains an
---- empty @ByteString@, it is still treated as empty, and the consuming
---- function is not called.
+{--
+   Run a consuming conduit repeatedly, only stopping when there is no more
+   data available from upstream.
+
+   In constrast to 'peekForever', this function will ignore empty
+   ByteStrings. So for example, if a stream of data contains an
+   empty @ByteString@, it is still treated as empty, and the consuming
+   function is not called.
+ -}
 peekForeverBS :: Monad m => ConduitT ByteString o m () -> ConduitT ByteString o m ()
 peekForeverBS inner =
     loop

--- a/src/main/frege/frege/data/conduit/internal/Pipe.fr
+++ b/src/main/frege/frege/data/conduit/internal/Pipe.fr
@@ -40,8 +40,10 @@ instance MonadIO m => MonadIO (Pipe l i o u m) where
 instance MonadResource m => MonadResource (Pipe l i o u m) where
     liftResourceT = lift . liftResourceT
 
---- This is similar to @await@, but will return the upstream result value as
---- @Left@ if available.
+{--
+   This is similar to @await@, but will return the upstream result value as
+   @Left@ if available.
+ -}
 awaitE :: Pipe l i o u m (Either u i)
 awaitE = NeedInput (Done . Right) (Done . Left)
 
@@ -78,12 +80,14 @@ runPipe (Done r) = return r
 runPipe (PipeM mp) = mp >>= runPipe
 runPipe (Leftover _ i) = absurd i
 
---- Transforms a @Pipe@ that provides leftovers to one which does not,
---- allowing it to be composed.
----
---- This function will provide any leftover values within this @Pipe@ to any
---- calls to @await@. If there are more leftover values than are demanded, the
---- remainder are discarded.
+{--
+   Transforms a @Pipe@ that provides leftovers to one which does not,
+   allowing it to be composed.
+
+   This function will provide any leftover values within this @Pipe@ to any
+   calls to @await@. If there are more leftover values than are demanded, the
+   remainder are discarded.
+ -}
 injectLeftovers :: Monad m => Pipe i i o u m r -> Pipe l i o u m r
 injectLeftovers =
     go []
@@ -95,8 +99,10 @@ injectLeftovers =
     go ls (PipeM mp) = PipeM (liftM (go ls) mp)
     go ls (Leftover p l) = go (l:ls) p
 
---- Returns a tuple of the upstream and downstream results. Note that this
---- will force consumption of the entire input stream.
+{--
+   Returns a tuple of the upstream and downstream results. Note that this
+   will force consumption of the entire input stream.
+ -}
 withUpstream :: Monad m => Pipe l i o u m r -> Pipe l i o u m (u, r)
 withUpstream down =
     down >>= go

--- a/src/main/frege/frege/data/conduit/internal/Sequence.fr
+++ b/src/main/frege/frege/data/conduit/internal/Sequence.fr
@@ -1,16 +1,18 @@
---- A collection of provisional class-like data types.
----
---- The original library uses @MonoFoldable@, @IsSequence@, etc. from the
---- @mono-traversable@ package. It uses \"type family\" feature which is not
---- (yet) available in Frege.
----
---- Functions which expects such classes are instead inplemented as two
---- variations: one is @fooE@ that takes a list, and the other is @fooStr@
---- that takes a String.
----
---- This module contains a data types whose members have the same name as the
---- original type classes so that transition to them when become available is
---- easier.
+{--
+   A collection of provisional class-like data types.
+
+   The original library uses @MonoFoldable@, @IsSequence@, etc. from the
+   @mono-traversable@ package. It uses \"type family\" feature which is not
+   (yet) available in Frege.
+
+   Functions which expects such classes are instead inplemented as two
+   variations: one is @fooE@ that takes a list, and the other is @fooStr@
+   that takes a String.
+
+   This module contains a data types whose members have the same name as the
+   original type classes so that transition to them when become available is
+   easier.
+ -}
 module frege.data.conduit.internal.Sequence where
 
 import frege.Prelude hiding (all, any, elem, fold, notElem, splitAt)

--- a/src/main/frege/frege/data/conduit/internal/StringCodec.fr
+++ b/src/main/frege/frege/data/conduit/internal/StringCodec.fr
@@ -15,8 +15,10 @@ pure native newString new :: JArray Byte -> Int -> Int -> Charset -> String
 encodeUtf8 :: String -> ByteString
 encodeUtf8 s = ST.run (BS.unsafeFreeze =<< getBytes s utf8)
 
---- Beware of cutoff; if the ByteString ends with an incomplete byte sequence,
---- the last character in the result String becomes U+FFFD (the replacement character).
+{--
+   Beware of cutoff; if the ByteString ends with an incomplete byte sequence,
+   the last character in the result String becomes U+FFFD (the replacement character).
+ -}
 decodeUtf8 :: ByteString -> String
 decodeUtf8 (ByteString{payload, offset, length}) =
     newString payload offset length utf8


### PR DESCRIPTION
The formatting of the documentation comment was fixed for correct rendering.

- The style `---\n---\n---\n` causes each line to be interpreted as a paragraph, which is undesirable.
- The style `{--\n -\n -\n ... -}` interprets leading ` -` to be a bullet point, which is undesirable.
- Code paragraphs surrounded by `@` were replaced with leading `>`s
- Bullet points represented by `*` were replaced with `-`
