### PR TITLE
Fix ByteString.pack and .unpack

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,9 @@
+# ChangeLog
+
+## 0.3.3 -- 2019-11-20
+
+### Bug fixes
+
+* Fix ByteString.pack (#9). Affected functions include:
+  * `ByteString.pack`
+  * `ByteString.singleton`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
-* Fix ByteString.pack (#9). Affected functions include:
+* Fixed `ByteString.pack` to correctly pack `[Byte]` into `ByteString` (#9). Affected functions include:
   * `ByteString.pack`
   * `ByteString.singleton`
+* Fixed out-of-bounds error in `ByteString.unpack` (#9). Affected functions include:
+  * `BSSeq.filter`
+  * `linesUnboundedAscii`

--- a/src/main/frege/frege/data/ByteString.fr
+++ b/src/main/frege/frege/data/ByteString.fr
@@ -160,16 +160,13 @@ native module where {
     return TByteString.mk(arr, 0, TByteString.length(a) + TByteString.length(b));
   }
 
-  public static final TByteString packImpl_(PreludeBase.TList<Byte> l, final int len) {
+  public static final TByteString packImpl_(final PreludeBase.TList<Byte> l, final int len) {
     final byte[] arr = new byte[len];
     int idx = 0;
-    while (l.asCons() != null) {
-      final PreludeBase.TList.DCons<Byte> cons = l.asCons();
-      assert cons != null;
-      final byte head = cons.mem1.call();
-      arr[idx] = head;
-      idx++;
-      l = cons.mem2.call();
+    PreludeBase.TList.DCons<Byte> cons = l.asCons();
+    while (cons != null) {
+      arr[idx++] = cons.mem1.call();
+      cons = cons.mem2.call().asCons();
     }
     return TByteString.mk(arr, 0, len);
   }

--- a/src/main/frege/frege/data/ByteString.fr
+++ b/src/main/frege/frege/data/ByteString.fr
@@ -163,7 +163,7 @@ native module where {
   public static final TByteString packImpl_(PreludeBase.TList<Byte> l, final int len) {
     final byte[] arr = new byte[len];
     int idx = 0;
-    while (l.asList() != null) {
+    while (l.asCons() != null) {
       final PreludeBase.TList.DCons<Byte> cons = l.asCons();
       assert cons != null;
       final byte head = cons.mem1.call();

--- a/src/main/frege/frege/data/ByteString.fr
+++ b/src/main/frege/frege/data/ByteString.fr
@@ -108,7 +108,7 @@ tail x
   | otherwise = drop 1 x
 
 unpack :: ByteString -> [Byte]
-unpack x = map (x !!) [0..(length x)]
+unpack x = map (x !!) [0..(length x - 1)]
 
 native module where {
   public static final byte[] thaw_(final TByteString bs) {

--- a/src/test/frege/frege/data/ByteStringTest.fr
+++ b/src/test/frege/frege/data/ByteStringTest.fr
@@ -1,0 +1,13 @@
+module frege.data.ByteStringTest where
+
+import frege.data.ByteString as BS ()
+import test.HspecLike (shouldBe)
+
+packTest :: IO ()
+packTest = do
+    let bytes = [65, 66, 67] -- "ABC"
+    (BS.unpack . BS.pack) bytes `shouldBe` bytes
+
+main :: IO ()
+main = do
+    packTest


### PR DESCRIPTION
The implementation of `ByteString.pack` (namely, `packImpl_`) failed to copy bytes from a Frege list to a Java array, resulting a ByteString entirely composed of null bytes. The loop condition was flipped to correctly branch on Frege lists in the native code.

Also, out-of-bounds access in `ByteString.unpack` was fixed.