### PR TITLE
Make sure the releasing action is run once

### DIFF
--- a/src/main/frege/frege/control/monad/trans/Resource.fr
+++ b/src/main/frege/frege/control/monad/trans/Resource.fr
@@ -145,7 +145,7 @@ private release' :: IORef ReleaseMap -> Int -> (Maybe (IO ()) -> IO a) -> IO a
 private release' istate key act = do
     rm <- istate.get
     let (rm', maction) = lookupAction rm
-    istate.put rm
+    istate.put rm'
     act maction
   where
     lookupAction (rm@(ReleaseMap next rf m)) =

--- a/src/test/frege/frege/control/monad/trans/ResourceTest.fr
+++ b/src/test/frege/frege/control/monad/trans/ResourceTest.fr
@@ -1,6 +1,6 @@
 module frege.control.monad.trans.ResourceTest where
 
-import frege.control.monad.trans.Resource (MonadResource, allocate, runResourceT)
+import frege.control.monad.trans.Resource (MonadResource, allocate, release, runResourceT)
 import test.HspecLike (shouldBe)
 
 data Action = Acquire Int | Release Int
@@ -24,6 +24,28 @@ orderedRelease = do
     -- xs should contain the reversed order of the performed actions
     xs `shouldBe` [Release 0, Release 1, Acquire 1, Acquire 0]
 
+--- Makes sure that resources are released once on exception.
+releaseOnceOnException :: IO ()
+releaseOnceOnException = do
+    counterRef <- Ref.new 0
+    void $ catchAll $ runResourceT $ do
+        _ <- allocate (pure ()) (\_ -> counterRef.modify (+1))
+        fail "exception!"
+    counter <- counterRef.get
+    counter `shouldBe` 1
+
+--- Makes sure a releasing action is run once if it is run early.
+releaseOnceEarly :: IO ()
+releaseOnceEarly = do
+    counterRef <- Ref.new 0
+    runResourceT $ do
+        (key, _) <- allocate (pure ()) (\_ -> counterRef.modify (+1))
+        release key
+    counter <- counterRef.get
+    counter `shouldBe` 1
+
 main :: IO ()
 main = do
     orderedRelease
+    releaseOnceOnException
+    releaseOnceEarly


### PR DESCRIPTION
If a resource is released early with the `release` function, it should not run again at the end of `runResourceT` block. This PR fixes a bug where releasing actions are run twice in such cases.

Affected functions include `bracketP`.